### PR TITLE
ApplicationDockItem: Ellipsize long window names

### DIFF
--- a/lib/Items/ApplicationDockItem.vala
+++ b/lib/Items/ApplicationDockItem.vala
@@ -38,6 +38,10 @@ namespace Plank
 		
 		private const string[] SUPPORTED_GETTEXT_DOMAINS_KEYS = {"X-Ubuntu-Gettext-Domain", "X-GNOME-Gettext-Domain"};
 		
+		// Longest reasonable window title length. Titles longer than this will be
+		// middle-ellipsized
+		private const int MAX_WINDOW_NAME_LENGTH = 48;
+
 		/**
 		 * Signal fired when the item's 'keep in dock' menu item is pressed.
 		 */
@@ -386,8 +390,17 @@ namespace Plank
 					}
 				}
 			}
-			
-			return window_name;
+
+			// Middle-ellipsize
+			string short_window_name = window_name;
+			if (window_name.length > MAX_WINDOW_NAME_LENGTH) {
+			  string first_half = window_name.substring (0, (int)(MAX_WINDOW_NAME_LENGTH / 2));
+			  string second_half = window_name.substring (-(int)(MAX_WINDOW_NAME_LENGTH / 2));
+
+			  short_window_name = "%s…%s".printf (first_half, second_half);
+			}
+
+			return short_window_name;
 		}
 		
 		/**


### PR DESCRIPTION
I tried using Pango’s ellipsize directly in the dock item's menu item, but couldn't figure that out. Then I noticed we already have a `shorten_window_name ()`  method, so I piggy-backed on that to handle ellipsizing the window name string directly.

Of course because we're doing this at the string level and not GTK, it's not as dynamic; we can't say we want the menu to be a certain pixel-width and have the string ellipsized to fit. I set the max length as a constant, but I wasn't sure how long was reasonable. After some trial and error, 48 chars felt about right.

## Screenshots:

### Before:

![Screenshot from 2020-02-21 14 35 40](https://user-images.githubusercontent.com/611168/75073875-a1e35500-54b7-11ea-804b-19fb8339b351.png)
![Screenshot from 2020-02-21 14 35 50](https://user-images.githubusercontent.com/611168/75073878-a3148200-54b7-11ea-93d7-d242d8884bf1.png)


### After:

![Screenshot from 2020-02-21 14 26 20](https://user-images.githubusercontent.com/611168/75073297-6005df00-54b6-11ea-94b9-f751ad2ce59e.png)
![Screenshot from 2020-02-21 14 25 53](https://user-images.githubusercontent.com/611168/75073299-61370c00-54b6-11ea-97c1-1ff46ab652b2.png)


Fixes #2 