### PR TITLE
Add translation into en_GB for Trash docklet

### DIFF
--- a/docklets/Trash/TrashDockItem.vala
+++ b/docklets/Trash/TrashDockItem.vala
@@ -91,7 +91,7 @@ namespace Docky
 			if (item_count == 0U)
 				Text = _("No items in Trash");
 			else
-				Text = ngettext ("%u item in Trash", "%u items in Trash", item_count).printf (item_count);
+				Text = ngettext (_("%u item in Trash"), _("%u items in Trash"), item_count).printf (item_count);
 			
 			Icon = DrawingService.get_icon_from_file (owned_file);
 		}

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -270,3 +270,7 @@ msgstr "All items in the Rubbish Bin will be permanently deleted."
 #: ../docklets/Trash/TrashDocklet.vala:36
 msgid "Trash"
 msgstr "Rubbish Bin"
+
+#: ../docklets/Trash/TrashDocklet.vala:41
+msgid "Have a look at your trash!"
+msgstr "Have a look at your rubbish!"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -238,3 +238,31 @@ msgstr "_Translate This Application..."
 #: ../lib/Widgets/PreferencesWindow.vala:90
 msgid "Preferences"
 msgstr "Preferences"
+
+#: ../docklets/Trash/TrashDockItem.vala:92
+msgid "No items in Trash"
+msgstr "No items in Rubbish Bin"
+
+#: ../docklets/Trash/TrashDockItem.vala:94
+msgid "%u item in Trash"
+msgstr "%u item in Rubbish Bin"
+
+#: ../docklets/Trash/TrashDockItem.vala:94
+msgid "%u items in Trash"
+msgstr "%u items in Rubbish Bin"
+
+#: ../docklets/Trash/TrashDockItem.vala:199
+msgid "_Open Trash"
+msgstr "_Open Rubbish Bin"
+
+#: ../docklets/Trash/TrashDockItem.vala:203
+msgid "Empty _Trash"
+msgstr "Empty _Rubbish Bin"
+
+#: ../docklets/Trash/TrashDockItem.vala:266
+msgid "Empty all items from Trash?"
+msgstr "Empty all items from Rubbish Bin?"
+
+#: ../docklets/Trash/TrashDockItem.vala:267
+msgid "All items in the Trash will be permanently deleted."
+msgstr "All items in the Rubbish Bin will be permanently deleted."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -266,3 +266,7 @@ msgstr "Empty all items from Rubbish Bin?"
 #: ../docklets/Trash/TrashDockItem.vala:267
 msgid "All items in the Trash will be permanently deleted."
 msgstr "All items in the Rubbish Bin will be permanently deleted."
+
+#: ../docklets/Trash/TrashDocklet.vala:36
+msgid "Trash"
+msgstr "Rubbish Bin"


### PR DESCRIPTION
Fixes #36 

Hi folks! As I have mentioned in the bug report, there were a couple of missing translations for British English. I have added them for the Trash docklet. I hope that those fixes are correct.