### PR TITLE
Support Granite dark style preference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
+        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgranite-dev libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
     - name: Build
       run: |
         meson -Denable-headless-tests=true build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgranite-dev libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
+        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgranite-dev elementary-default-settings libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
     - name: Build
       run: |
         meson -Denable-headless-tests=true build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgranite-dev elementary-default-settings libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
+        apt install -y at-spi2-core dbus-x11 gnome-common libbamf3-dev libcairo2-dev libdbusmenu-gtk3-dev libgdk-pixbuf2.0-dev libgee-0.8-dev libglib2.0-dev libgnome-menu-3-dev libgranite-dev elementary-default-settings accountsservice libgtk-3-dev libwnck-3-dev libx11-dev libxml2-utils meson valac xvfb
     - name: Build
       run: |
         meson -Denable-headless-tests=true build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,5 +20,5 @@ jobs:
       run: |
         meson -Denable-headless-tests=true build
         ninja -C build
-        ninja -C build test
+        xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24" dbus-run-session -- tests/headless_runner.sh "ninja -C build test"
         ninja -C build install

--- a/lib/DockRenderer.vala
+++ b/lib/DockRenderer.vala
@@ -74,6 +74,7 @@ namespace Plank
 		bool zoom_changed = false;
 		
 		ulong gtk_theme_name_changed_handler_id = 0UL;
+		ulong granite_prefers_color_scheme_handler_id = 0UL;
 		
 		double dynamic_animation_offset = 0.0;
 		
@@ -183,9 +184,18 @@ namespace Plank
 			if (name == Theme.GTK_THEME_NAME) {
 				if (gtk_theme_name_changed_handler_id == 0UL)
 					gtk_theme_name_changed_handler_id = Gtk.Settings.get_default ().notify["gtk-theme-name"].connect (load_theme);
-			} else if (gtk_theme_name_changed_handler_id > 0UL) {
-				SignalHandler.disconnect (Gtk.Settings.get_default (), gtk_theme_name_changed_handler_id);
-				gtk_theme_name_changed_handler_id = 0UL;
+				if (granite_prefers_color_scheme_handler_id == 0UL)
+					granite_prefers_color_scheme_handler_id = Granite.Settings.get_default ().notify["prefers-color-scheme"].connect (load_theme);
+			} else {
+				if (gtk_theme_name_changed_handler_id > 0UL) {
+					SignalHandler.disconnect (Gtk.Settings.get_default (), gtk_theme_name_changed_handler_id);
+					gtk_theme_name_changed_handler_id = 0UL;
+				}
+
+				if (granite_prefers_color_scheme_handler_id > 0UL) {
+					SignalHandler.disconnect (Granite.Settings.get_default (), granite_prefers_color_scheme_handler_id);
+					granite_prefers_color_scheme_handler_id = 0UL;
+				}
 			}
 			
 			theme = new DockTheme (name);

--- a/lib/Drawing/Theme.vala
+++ b/lib/Drawing/Theme.vala
@@ -471,12 +471,19 @@ namespace Plank
 		{
 			File folder;
 			unowned string exec_name = Paths.AppName;
+			string folder_name = exec_name;
+
+			// If the OS supports Pantheon's dark preference, the stylesheet should provide a -dark dock theme
+			if (Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK) {
+				folder_name += "-dark";
+			}
+
 			var name = Gtk.Settings.get_default ().gtk_theme_name;
 					
 			// Look in user's xdg-themes-folder
 			folder = Paths.DataHomeFolder.get_child ("themes/%s".printf (name));
 			if (folder.query_exists ()) {
-				folder = folder.get_child (exec_name);
+				folder = folder.get_child (folder_name);
 				if (folder.query_exists ()
 					&& folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY)
 					return folder;
@@ -488,7 +495,7 @@ namespace Plank
 			// Look in user's legacy xdg-themes-folder
 			folder = Paths.HomeFolder.get_child (".themes/%s".printf (name));
 			if (folder.query_exists ()) {
-				folder = folder.get_child (exec_name);
+				folder = folder.get_child (folder_name);
 				if (folder.query_exists ()
 					&& folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY)
 					return folder;
@@ -499,7 +506,7 @@ namespace Plank
 			
 			// Look in system's xdg-themes-folders
 			foreach (var datafolder in Paths.DataDirFolders) {
-				folder = datafolder.get_child ("themes/%s/%s".printf (name, exec_name));
+				folder = datafolder.get_child ("themes/%s/%s".printf (name, folder_name));
 				if (folder.query_exists ()
 					&& folder.query_file_type (FileQueryInfoFlags.NONE, null) == FileType.DIRECTORY)
 					return folder;

--- a/lib/Widgets/DockWindow.vala
+++ b/lib/Widgets/DockWindow.vala
@@ -72,7 +72,16 @@ namespace Plank
 		public DockWindow (DockController controller)
 		{
 			GLib.Object (controller: controller, type: Gtk.WindowType.TOPLEVEL, type_hint: Gdk.WindowTypeHint.DOCK);
-		}
+
+			var granite_settings = Granite.Settings.get_default ();
+			var gtk_settings = Gtk.Settings.get_default ();
+
+			gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+
+			granite_settings.notify["prefers-color-scheme"].connect (() => {
+				gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+			});
+	}
 		
 		construct
 		{

--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,7 @@ add_project_arguments([
 
 # Dependencies
 glib_version_required = '2.40.0'
+granite_version_required = '5.4.0'
 gtk_version_required = '3.10.0'
 gdk_pixbuf_version_required = '2.26.0'
 bamf_version_required = '0.4.0'
@@ -104,6 +105,7 @@ cairo_version_required = '1.13'
 
 gio_dep = [dependency('gio-2.0', version: '>= @0@'.format(glib_version_required)), dependency('gio-unix-2.0')]
 gmodule_dep = dependency('gmodule-2.0', version: '>= @0@'.format(glib_version_required))
+granite_dep = dependency('granite', version: '>= @0@'.format(gtk_version_required))
 gtk_dep = [dependency('gtk+-3.0', version: '>= @0@'.format(gtk_version_required)), dependency('gdk-x11-3.0')]
 gdk_pixbuf_dep = dependency('gdk-pixbuf-2.0', version: '>= @0@'.format(gdk_pixbuf_version_required))
 gee_dep = dependency('gee-0.8')
@@ -114,7 +116,7 @@ gnomemenu_dep = dependency('libgnome-menu-3.0')
 posix_dep = vala.find_library('posix')
 m_dep = cc.find_library('m', required: false)
 
-plank_base_dep = [gio_dep, gee_dep, gtk_dep, bamf_dep]
+plank_base_dep = [gio_dep, gee_dep, granite_dep, gtk_dep, bamf_dep]
 
 # Support dynamic quicklists provided with dbusmenu
 enable_dbusmenu = get_option('enable-dbusmenu')

--- a/tests/headless_runner.sh
+++ b/tests/headless_runner.sh
@@ -1,2 +1,8 @@
 #!/bin/sh
-xvfb-run --auto-servernum --server-args="-screen 0 1280x1024x24" dbus-run-session "$1"
+mkdir -p /run/dbus
+mkdir -p /var
+ln -s /var/run /run
+
+dbus-daemon --system --fork
+
+$1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -46,7 +46,6 @@ test_env = [
 if enable_headless_tests
 	add_test_setup(
 		'default',
-		exe_wrapper: [join_paths(meson.source_root(), 'tests', 'headless_runner.sh')],
 		env: test_env,
 		is_default: true
 	)


### PR DESCRIPTION
Depends on https://github.com/elementary/stylesheet/pull/609 and Granite 5.4.

- [x] Add Granite dep
- [x] Add support for a `plank-dark` folder in the stylesheet
- [x] Bind to the Granite preference and change the theme on the fly
- [x] Request dark GTK variant to fix menus