### PR TITLE
Styling: Remove Active Window Dock Glow

### DIFF
--- a/lib/DockRenderer.vala
+++ b/lib/DockRenderer.vala
@@ -803,14 +803,14 @@ namespace Plank
 				icon_cr.set_operator (Cairo.Operator.OVER);
 			}
 			
-			// draw active glow
-			var active_time = int64.max (0LL, frame_time - item.LastActive);
-			var opacity = double.min (1, active_time / (double) (theme.ActiveTime * 1000));
-			if ((item.State & ItemState.ACTIVE) == 0)
-				opacity = 1 - opacity;
-			if (opacity > 0) {
-				theme.draw_active_glow (item_buffer, background_rect, draw_value.background_region, item.AverageIconColor, opacity, position);
-			}
+			// draw active glow (DEPRECATED - window styling improved, now has backdrop styling so this isn't needed anymore)
+			//var active_time = int64.max (0LL, frame_time - item.LastActive);
+			//var opacity = double.min (1, active_time / (double) (theme.ActiveTime * 1000));
+			//if ((item.State & ItemState.ACTIVE) == 0)
+			//	opacity = 1 - opacity;
+			//if (opacity > 0) {
+			//	theme.draw_active_glow (item_buffer, background_rect, draw_value.background_region, item.AverageIconColor, opacity, position);
+			//}
 			
 			// draw the icon
 			if (window_scale_factor > 1) {

--- a/lib/DockRenderer.vala
+++ b/lib/DockRenderer.vala
@@ -25,27 +25,27 @@ namespace Plank
 	public class DockRenderer : Renderer
 	{
 		public DockController controller { private get; construct; }
-		
+
 		public DockTheme theme { get; private set; }
-		
+
 		/**
 		 * The current progress [0.0..1.0] of the hide-animation of the dock.
 		 */
 		[CCode (notify = false)]
 		public double hide_progress { get; private set; }
-		
+
 		/**
 		 * The current opacity of the dock.
 		 */
 		[CCode (notify = false)]
 		double opacity { get; private set; }
-		
+
 		/**
 		 * The current progress [0.0..1.0] of the zoom-in-animation of the dock.
 		 */
 		[CCode (notify = false)]
 		public double zoom_in_progress { get; private set; }
-		
+
 		/**
 		 * The current local cursor-position on the dock if hovered.
 		 */
@@ -56,34 +56,34 @@ namespace Plank
 		Surface? fade_buffer = null;
 		Surface? item_buffer = null;
 		Surface? shadow_buffer = null;
-		
+
 		Surface? background_buffer = null;
 		Gdk.Rectangle background_rect;
 		Surface? indicator_buffer = null;
 		Surface? urgent_indicator_buffer = null;
 		Surface? urgent_glow_buffer = null;
-		
+
 		int64 last_hide = 0LL;
 		int64 last_hovered_changed = 0LL;
-		
+
 		bool screen_is_composited = false;
 		bool show_notifications = true;
 		uint reset_position_manager_timer_id = 0U;
 		int window_scale_factor = 1;
 		bool is_first_frame = true;
 		bool zoom_changed = false;
-		
+
 		ulong gtk_theme_name_changed_handler_id = 0UL;
 		ulong granite_prefers_color_scheme_handler_id = 0UL;
-		
+
 		double dynamic_animation_offset = 0.0;
-		
+
 		Gee.ArrayList<unowned DockItem> current_items;
 		Gee.HashSet<DockItem> transient_items;
 #if BENCHMARK
 		Gee.ArrayList<string> benchmark;
 #endif
-		
+
 		/**
 		 * Create a new dock renderer for a dock.
 		 *
@@ -94,7 +94,7 @@ namespace Plank
 		{
 			GLib.Object (controller : controller, widget : window);
 		}
-		
+
 		construct
 		{
 			transient_items = new Gee.HashSet<DockItem> ();
@@ -103,10 +103,10 @@ namespace Plank
 			benchmark = new Gee.ArrayList<string> ();
 #endif
 			controller.prefs.notify.connect (prefs_changed);
-			
+
 			load_theme ();
 		}
-		
+
 		/**
 		 * Initializes the renderer.  Call after the DockWindow is constructed.
 		 */
@@ -114,22 +114,22 @@ namespace Plank
 			requires (controller.window != null)
 		{
 			controller.position_manager.update (theme);
-			
+
 			controller.window.notify["HoveredItem"].connect (animated_draw);
 			controller.hide_manager.notify["Hidden"].connect (hidden_changed);
 			controller.hide_manager.notify["Hovered"].connect (hovered_changed);
 		}
-		
+
 		~DockRenderer ()
 		{
 			controller.prefs.notify.disconnect (prefs_changed);
 			theme.notify.disconnect (theme_changed);
-			
+
 			controller.hide_manager.notify["Hidden"].disconnect (hidden_changed);
 			controller.hide_manager.notify["Hovered"].disconnect (hovered_changed);
 			controller.window.notify["HoveredItem"].disconnect (animated_draw);
 		}
-		
+
 		void prefs_changed (Object prefs, ParamSpec prop)
 		{
 			switch (prop.name) {
@@ -148,38 +148,38 @@ namespace Plank
 				break;
 			}
 		}
-		
+
 		void theme_changed ()
 		{
 			reset_position_manager ();
 		}
-		
+
 		void reset_position_manager ()
 		{
 			// Don't perform an update immediately and summon further
 			// update-requests, wait at least 50ms after the last request
-			
+
 			if (reset_position_manager_timer_id > 0U)
 				Source.remove (reset_position_manager_timer_id);
-			
+
 			reset_position_manager_timer_id = Gdk.threads_add_timeout (50, () => {
 				reset_position_manager_timer_id = 0U;
-				
+
 				reset_buffers ();
 				reset_item_buffers ();
 				controller.position_manager.update (theme);
-				
+
 				return false;
 			});
 		}
-		
+
 		void load_theme ()
 		{
 			var is_reload = (theme != null);
-			
+
 			if (is_reload)
 				theme.notify.disconnect (theme_changed);
-			
+
 			unowned string name = controller.prefs.Theme;
 			if (name == Theme.GTK_THEME_NAME) {
 				if (gtk_theme_name_changed_handler_id == 0UL)
@@ -197,70 +197,70 @@ namespace Plank
 					granite_prefers_color_scheme_handler_id = 0UL;
 				}
 			}
-			
+
 			theme = new DockTheme (name);
 			theme.load ("dock");
 			theme.notify.connect (theme_changed);
-			
+
 			if (is_reload)
 				theme_changed ();
 		}
-		
+
 		/**
 		 * Resets all internal buffers and forces a redraw.
 		 */
 		public void reset_buffers ()
 		{
 			Logger.verbose ("DockRenderer.reset_buffers ()");
-			
+
 			main_buffer = null;
 			fade_buffer = null;
 			item_buffer = null;
 			shadow_buffer = null;
-			
+
 			background_buffer = null;
 			indicator_buffer = null;
 			urgent_indicator_buffer = null;
 			urgent_glow_buffer = null;
-			
+
 			animated_draw ();
 		}
-		
+
 		/**
 		 * Resets all internal item buffers and forces a redraw.
 		 */
 		void reset_item_buffers ()
 		{
 			Logger.verbose ("DockRenderer.reset_item_buffers ()");
-			
+
 			controller.reset_buffers ();
-			
+
 			animated_draw ();
 		}
-		
+
 		/**
 		 * {@inheritDoc}
 		 */
 		protected override void initialize_frame (int64 frame_time)
 		{
 			return_if_fail (theme != null);
-			
+
 			unowned Gee.ArrayList<unowned DockItem> new_items = controller.VisibleItems;
-			
+
 			// FIXME This should never happen
 			if (new_items.size <= 0) {
 				critical ("No items available to initialize frame");
 				return;
 			}
-			
+
 			unowned PositionManager position_manager = controller.position_manager;
-			
+
 			screen_is_composited = position_manager.screen_is_composited;
 			show_notifications = EnvironmentSettings.get_instance ().ShowNotifications;
 			dynamic_animation_offset = 0.0;
-			
+
 			var fade_opacity = theme.FadeOpacity;
-			
+
 			if (screen_is_composited) {
 				var hide_duration = (fade_opacity == 1.0 ? theme.HideTime : theme.FadeTime) * 1000;
 				var hide_time = int64.max (0LL, frame_time - last_hide);
@@ -272,7 +272,7 @@ namespace Plank
 				} else {
 					hide_progress = (controller.hide_manager.Hidden ? 1.0 : 0.0);
 				}
-				
+
 				var zoom_duration = DOCK_ZOOM_DURATION * 1000;
 				var zoom_time = int64.max (0LL, frame_time - last_hovered_changed);
 				double zoom_progress;
@@ -289,28 +289,28 @@ namespace Plank
 				hide_progress = 0.0;
 				zoom_in_progress = 0.0;
 			}
-			
+
 			if (fade_opacity < 1.0)
 				opacity = 1.0 - (1.0 - fade_opacity) * hide_progress;
 			else
 				opacity = 1.0;
-			
+
 			// Update *ordered* list of items
 			current_items.clear ();
 			current_items.add_all (new_items);
-			
+
 			if (screen_is_composited) {
 				var add_time = 0LL;
 				var remove_time = 0LL;
 				var move_time = 0LL;
 				var move_duration = theme.ItemMoveTime * 1000;
-				
+
 				var transient_items_it = transient_items.iterator ();
 				while (transient_items_it.next ()) {
 					var item = transient_items_it.get ();
 					add_time = item.AddTime;
 					remove_time = item.RemoveTime;
-					
+
 					if (add_time > remove_time) {
 						move_time = frame_time - add_time;
 						if (move_time < move_duration) {
@@ -332,17 +332,17 @@ namespace Plank
 			} else {
 				transient_items.clear ();
 			}
-			
+
 			current_items.sort ((CompareDataFunc) compare_dock_item_position);
-			
+
 			// Calculate positions for given ordered list of items
 			position_manager.update_draw_values (current_items,
 				(DrawValueFunc) animate_draw_value_for_item,
 				(DrawValuesFunc) post_process_draw_values);
-			
+
 			background_rect = position_manager.get_background_region ();
 		}
-		
+
 		/**
 		 * {@inheritDoc}
 		 */
@@ -353,31 +353,31 @@ namespace Plank
 				critical ("No items available to draw frame");
 				return;
 			}
-			
+
 			window_scale_factor = controller.window.get_window ().get_scale_factor ();
 			// take the previous frame values into account to decide if we
 			// can bail a full draw to not miss a finishing animation-frame
 			var no_full_draw_needed = (!is_first_frame && hide_progress == 1.0 && opacity == 1.0);
-			
+
 			unowned PositionManager position_manager = controller.position_manager;
 			unowned DockItem dragged_item = controller.drag_manager.DragItem;
 			var win_rect = position_manager.get_dock_window_region ();
-			
+
 			if (main_buffer == null) {
 				main_buffer = new Surface.with_cairo_surface (win_rect.width, win_rect.height, cr.get_target ());
 				main_buffer.Internal.set_device_scale (window_scale_factor, window_scale_factor);
 			}
-			
+
 			if (item_buffer == null) {
 				item_buffer = new Surface.with_cairo_surface (win_rect.width, win_rect.height, cr.get_target ());
 				item_buffer.Internal.set_device_scale (window_scale_factor, window_scale_factor);
 			}
-			
+
 			if (shadow_buffer == null) {
 				shadow_buffer = new Surface.with_cairo_surface (win_rect.width, win_rect.height, cr.get_target ());
 				shadow_buffer.Internal.set_device_scale (window_scale_factor, window_scale_factor);
 			}
-			
+
 			// if the dock is completely hidden and not transparently drawn
 			// only draw ugent-glow indicators and bail since there is no need
 			// for further things
@@ -387,11 +387,11 @@ namespace Plank
 				cr.set_operator (Cairo.Operator.CLEAR);
 				cr.paint ();
 				cr.restore ();
-				
+
 				if (show_notifications)
 					foreach (unowned DockItem item in current_items)
 						draw_urgent_glow (item, cr, frame_time);
-				
+
 				return;
 			}
 
@@ -399,29 +399,29 @@ namespace Plank
 				fade_buffer = new Surface.with_cairo_surface (win_rect.width, win_rect.height, cr.get_target ());
 				fade_buffer.Internal.set_device_scale (window_scale_factor, window_scale_factor);
 			}
-			
+
 #if BENCHMARK
 			DateTime start, start2, end, end2;
 			benchmark.clear ();
 			start = new DateTime.now_local ();
 #endif
-			
+
 			main_buffer.clear ();
 			item_buffer.clear ();
 			shadow_buffer.clear ();
 			unowned Cairo.Context item_cr = item_buffer.Context;
 			unowned Cairo.Context shadow_cr = shadow_buffer.Context;
-			
+
 			// calculate drawing offset
 			var x_offset = 0, y_offset = 0;
 			if (opacity == 1.0)
 				position_manager.get_dock_draw_position (out x_offset, out y_offset);
-			
+
 			// composite dock layers and make sure to draw onto the window's context with one operation
 			main_buffer.clear ();
 			unowned Cairo.Context main_cr = main_buffer.Context;
 			main_cr.set_operator (Cairo.Operator.OVER);
-			
+
 #if BENCHMARK
 			start2 = new DateTime.now_local ();
 #endif
@@ -431,7 +431,7 @@ namespace Plank
 			end2 = new DateTime.now_local ();
 			benchmark.add ("background render time - %f ms".printf (end2.difference (start2) / 1000.0));
 #endif
-			
+
 			// draw each item onto the dock buffer
 			foreach (unowned DockItem item in current_items) {
 #if BENCHMARK
@@ -448,15 +448,15 @@ namespace Plank
 				benchmark.add ("item render time - %f ms".printf (end2.difference (start2) / 1000.0));
 #endif
 			}
-			
+
 			// draw items-shadow-layer
 			main_cr.set_source_surface (shadow_buffer.Internal, x_offset, y_offset);
 			main_cr.paint ();
-			
+
 			// draw items-layer
 			main_cr.set_source_surface (item_buffer.Internal, x_offset, y_offset);
 			main_cr.paint ();
-			
+
 			// draw the dock on the window and fade it if need be
 			cr.set_operator (Cairo.Operator.SOURCE);
 			if (opacity < 1.0) {
@@ -465,19 +465,19 @@ namespace Plank
 				fade_cr.set_operator (Cairo.Operator.OVER);
 				fade_cr.set_source_surface (main_buffer.Internal, 0, 0);
 				fade_cr.paint_with_alpha (opacity);
-				
+
 				cr.set_source_surface (fade_buffer.Internal, 0, 0);
 			} else {
 				cr.set_source_surface (main_buffer.Internal, 0, 0);
 			}
 			cr.paint ();
-			
+
 			// draw urgent-glow if dock is completely hidden
 			if (show_notifications && hide_progress == 1.0) {
 				foreach (unowned DockItem item in current_items)
 					draw_urgent_glow (item, cr, frame_time);
 			}
-			
+
 #if BENCHMARK
 			end = new DateTime.now_local ();
 			var diff = end.difference (start) / 1000.0;
@@ -486,78 +486,78 @@ namespace Plank
 					message ("	" + s);
 			message ("render time - %f ms", diff);
 #endif
-			
+
 			if (is_first_frame) {
 				message ("Cairo.SurfaceType: %s", cairo_surface_type_to_string (cr.get_target ().get_type ()));
-				
+
 				Gdk.threads_add_idle_full (GLib.Priority.LOW, () => {
 					unowned HideManager hide_manager = controller.hide_manager;
-					
+
 					// FIXME HideManager.initialize () -> setup_active_window ();
 					// is already taking care of updating the Hidden-state,
 					// but only if there is already an active/open window
 					if (hide_manager.Hidden)
 						return false;
-					
+
 					// slide the dock in, if it shouldnt start hidden
 					hide_manager.update_hovered ();
-					
+
 					// FIXME there must be a sane way
 					// https://bugs.launchpad.net/plank/+bug/1256626
 					force_frame_time_update ();
 					last_hide = frame_time;
-					
+
 					hidden_changed ();
 					return false;
 				});
-				
+
 				is_first_frame = false;
 			}
 		}
-		
+
 		void draw_dock_background (Cairo.Context cr, Gdk.Rectangle background_rect, int x_offset, int y_offset)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
-			
+
 			if (background_rect.width <= 0 || background_rect.height <= 0) {
 				background_buffer = null;
 				return;
 			}
-			
+
 			if (background_buffer == null || background_buffer.Width != background_rect.width
 				|| background_buffer.Height != background_rect.height)
 				background_buffer = theme.create_background (background_rect.width, background_rect.height,
 					position_manager.Position, main_buffer);
-			
+
 			if (hide_progress > 0.0 && theme.CascadeHide) {
 				int x, y;
 				position_manager.get_background_padding (out x, out y);
 				x_offset -= (int) (x * hide_progress);
 				y_offset -= (int) (y * hide_progress);
 			}
-			
+
 			cr.set_source_surface (background_buffer.Internal, background_rect.x + x_offset, background_rect.y + y_offset);
 			cr.paint ();
 		}
-		
+
 		[CCode (instance_pos = -1)]
 		void animate_draw_value_for_item (DockItem item, DockItemDrawValue draw_value)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
 			unowned DockItem hovered_item = controller.window.HoveredItem;
 			unowned DragManager drag_manager = controller.drag_manager;
-			
+
 			var icon_size = (int) draw_value.icon_size;
 			var position = position_manager.Position;
 			var x_offset = 0.0, y_offset = 0.0;
-			
+
 			// check for and calculate click-animation
 			var max_click_time = item.ClickedAnimation == AnimationType.BOUNCE ? theme.LaunchBounceTime : theme.ClickTime;
 			max_click_time *= 1000;
 			var click_time = int64.max (0LL, frame_time - item.LastClicked);
 			if (click_time < max_click_time) {
 				var click_animation_progress = click_time / (double) max_click_time;
-				
+
 				switch (item.ClickedAnimation) {
 				default:
 				case AnimationType.NONE:
@@ -574,13 +574,13 @@ namespace Plank
 					break;
 				}
 			}
-			
+
 			// check for and calculate scroll-animation
 			var max_scroll_time = ITEM_SCROLL_DURATION * 1000;
 			var scroll_time = int64.max (0LL, frame_time - item.LastScrolled);
 			if (scroll_time < max_scroll_time) {
 				var scroll_animation_progress = scroll_time / (double) max_scroll_time;
-				
+
 				switch (item.ScrolledAnimation) {
 				default:
 				case AnimationType.NONE:
@@ -593,7 +593,7 @@ namespace Plank
 					break;
 				}
 			}
-			
+
 			// check for and calculate hover-animation
 			var max_hover_time = ITEM_HOVER_DURATION * 1000;
 			var hover_time = int64.max (0LL, frame_time - item.LastHovered);
@@ -604,7 +604,7 @@ namespace Plank
 				} else {
 					hover_animation_progress = 1.0 - easing_for_mode (AnimationMode.LINEAR, hover_time, max_hover_time);
 				}
-				
+
 				switch (item.HoveredAnimation) {
 				default:
 				case AnimationType.NONE:
@@ -616,14 +616,14 @@ namespace Plank
 			} else if (hovered_item == item) {
 				draw_value.lighten = 0.2;
 			}
-			
+
 			if (hovered_item == item && controller.window.menu_is_visible ())
 				draw_value.darken += 0.4;
 			else if (drag_manager.ExternalDragActive
 				&& drag_manager.DragNeedsCheck
 				&& !drag_manager.drop_is_accepted_by (item))
 				draw_value.darken += 0.6;
-			
+
 			// bounce icon on urgent state
 			if (screen_is_composited && show_notifications && (item.State & ItemState.URGENT) != 0) {
 				var urgent_duration = theme.UrgentBounceTime * 1000;
@@ -631,7 +631,7 @@ namespace Plank
 				if (urgent_time < urgent_duration)
 					y_offset += position_manager.UrgentBounceHeight * easing_bounce (urgent_time, urgent_duration, 1.0);
 			}
-			
+
 			// animate addition/removal
 			unowned DockContainer? container = item.Container;
 			var allow_animation = (screen_is_composited && (container == null || container.AddTime < item.AddTime));
@@ -643,7 +643,7 @@ namespace Plank
 					draw_value.opacity = easing_for_mode (AnimationMode.EASE_IN_EXPO, move_time, move_duration);
 					y_offset -= move_animation_progress * (icon_size + position_manager.BottomPadding);
 					draw_value.show_indicator = false;
-					
+
 					// calculate the resulting incremental dynamic-animation-offset used to animate the background-resize and icon-offset
 					move_animation_progress = 1.0 - easing_for_mode (AnimationMode.EASE_OUT_QUINT, move_time, move_duration);
 					dynamic_animation_offset -= move_animation_progress * (icon_size + position_manager.ItemPadding);
@@ -657,14 +657,14 @@ namespace Plank
 					draw_value.opacity = 1.0 - easing_for_mode (AnimationMode.EASE_OUT_EXPO, move_time, move_duration);
 					y_offset -= move_animation_progress * (icon_size + position_manager.BottomPadding);
 					draw_value.show_indicator = false;
-					
+
 					// calculate the resulting incremental dynamic-animation-offset used to animate the background-resize and icon-offset
 					move_animation_progress = 1.0 - easing_for_mode (AnimationMode.EASE_IN_QUINT, move_time, move_duration);
 					dynamic_animation_offset += move_animation_progress * (icon_size + position_manager.ItemPadding);
 					x_offset += dynamic_animation_offset - (icon_size + position_manager.ItemPadding);
 				}
 			}
-			
+
 			// animate icon movement on move state
 			if ((item.State & ItemState.MOVE) != 0) {
 				var move_duration = theme.ItemMoveTime * 1000;
@@ -685,7 +685,7 @@ namespace Plank
 					item.unset_move_state ();
 				}
 			}
-			
+
 			// animate icon on invalid state
 			if ((item.State & ItemState.INVALID) != 0) {
 				var invalid_duration = ITEM_INVALID_DURATION * 1000;
@@ -696,25 +696,25 @@ namespace Plank
 					draw_value.opacity = 0.10;
 				}
 			}
-			
+
 			if (x_offset != 0.0)
 				draw_value.move_right (position, x_offset);
-			
+
 			if (y_offset != 0.0)
 				draw_value.move_in (position, y_offset);
 		}
-		
+
 		[CCode (instance_pos = -1)]
 		void post_process_draw_values (Gee.HashMap<DockElement, DockItemDrawValue?> draw_values)
 		{
 			if (dynamic_animation_offset == 0.0)
 				return;
-			
+
 			unowned PositionManager position_manager = controller.position_manager;
 			var position = position_manager.Position;
-			
+
 			var x_offset = 0.0;
-			
+
 			switch (position_manager.Alignment) {
 			default:
 			case Gtk.Align.CENTER:
@@ -740,22 +740,22 @@ namespace Plank
 				}
 				break;
 			}
-			
+
 			if (x_offset == 0.0)
 				return;
-			
+
 			draw_values.map_iterator ().foreach ((i, val) => {
 				val.move_right (position, x_offset);
 				return true;
 			});
 		}
-		
+
 		inline Surface get_item_surface (DockItem item, int icon_size)
 		{
 			var private_icon_surface = item.get_surface (icon_size, icon_size, item_buffer);
 			if (!screen_is_composited)
 				return private_icon_surface;
-			
+
 			// FIXME There is probably a nicer way to accomplish this
 			// Check if the underlying cache returned a marked surface and if needed
 			// request another draw with the currently assumed largest required size
@@ -766,44 +766,44 @@ namespace Plank
 				&& ((drawing_status = private_icon_surface.steal_qdata<string> (quark_surface_stats)) != null
 				&& drawing_status == SURFACE_STATS_DRAWING_TIME_EXCEEDED))
 				item.get_surface (max_icon_size, max_icon_size, item_buffer);
-			
+
 			return private_icon_surface;
 		}
-		
+
 		void draw_item (Cairo.Context cr, DockItem item, DockItemDrawValue draw_value, int64 frame_time)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
 			var icon_size = (int) draw_value.icon_size * window_scale_factor;
 			var position = position_manager.Position;
-			
+
 			// load the icon
 #if BENCHMARK
 			var start = new DateTime.now_local ();
 #endif
 			var icon_surface = get_item_surface (item, icon_size).copy ();
 			unowned Cairo.Context icon_cr = icon_surface.Context;
-			
+
 			Surface? icon_overlay_surface = null;
 			if (item.CountVisible || item.ProgressVisible)
 				icon_overlay_surface = item.get_foreground_surface (icon_size, icon_size, item_buffer, (DrawDataFunc<DockItem>) draw_item_foreground);
-			
+
 			if (icon_overlay_surface != null) {
 				icon_cr.set_source_surface (icon_overlay_surface.Internal, 0, 0);
 				icon_cr.paint ();
 			}
-			
+
 #if BENCHMARK
 			var end = new DateTime.now_local ();
 			benchmark.add ("	item.get_surface time - %f ms".printf (end.difference (start) / 1000.0));
 #endif
-			
+
 			// lighten the icon
 			if (draw_value.lighten > 0) {
 				icon_cr.set_operator (Cairo.Operator.ADD);
 				icon_cr.paint_with_alpha (draw_value.lighten);
 				icon_cr.set_operator (Cairo.Operator.OVER);
 			}
-			
+
 			// darken the icon
 			if (draw_value.darken > 0) {
 				icon_cr.rectangle (0, 0, icon_surface.Width, icon_surface.Height);
@@ -812,16 +812,7 @@ namespace Plank
 				icon_cr.fill ();
 				icon_cr.set_operator (Cairo.Operator.OVER);
 			}
-			
-			// draw active glow (DEPRECATED - window styling improved, now has backdrop styling so this isn't needed anymore)
-			//var active_time = int64.max (0LL, frame_time - item.LastActive);
-			//var opacity = double.min (1, active_time / (double) (theme.ActiveTime * 1000));
-			//if ((item.State & ItemState.ACTIVE) == 0)
-			//	opacity = 1 - opacity;
-			//if (opacity > 0) {
-			//	theme.draw_active_glow (item_buffer, background_rect, draw_value.background_region, item.AverageIconColor, opacity, position);
-			//}
-			
+
 			// draw the icon
 			if (window_scale_factor > 1) {
 				cr.save ();
@@ -835,24 +826,24 @@ namespace Plank
 				cr.paint ();
 			if (window_scale_factor > 1)
 				cr.restore ();
-			
+
 			// draw indicators
 			if (draw_value.show_indicator && item.Indicator != IndicatorState.NONE)
 				draw_indicator_state (cr, draw_value.hover_region, item.Indicator, item.State);
 		}
-		
+
 		void draw_item_shadow (Cairo.Context cr, DockItem item, DockItemDrawValue draw_value)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
 			var shadow_size = position_manager.IconShadowSize;
 			// Inflate size to fit shadow
 			var icon_size = (int) (draw_value.icon_size + 2 * shadow_size) * window_scale_factor;
-			
+
 			// load and draw the icon shadow
 			Surface? icon_shadow_surface = null;
 			if (shadow_size > 0)
 				icon_shadow_surface = item.get_background_surface (icon_size, icon_size, item_buffer, (DrawDataFunc<DockItem>) draw_item_background);
-			
+
 			if (icon_shadow_surface != null) {
 				if (window_scale_factor > 1) {
 					cr.save ();
@@ -869,46 +860,46 @@ namespace Plank
 					cr.restore ();
 			}
 		}
-		
+
 		[CCode (instance_pos = -1)]
 		Surface draw_item_foreground (int width, int height, Surface model, DockItem item)
 		{
 			Logger.verbose ("DockItem.draw_item_overlay (width = %i, height = %i)", width, height);
 			var surface = new Surface.with_surface (width, height, model);
-			
+
 			var icon_size = int.min (width, height);
 			var urgent_color = theme.BadgeColor;
 			if (urgent_color.equal ({0.0, 0.0, 0.0, 0.0})) {
 				urgent_color = get_styled_color ();
 				urgent_color.add_hue (theme.UrgentHueShift);
 			}
-			
+
 			// draw item's count
 			if (item.CountVisible)
 				theme.draw_item_count (surface, icon_size, urgent_color, item.Count);
-			
+
 			// draw item's progress
 			if (item.ProgressVisible)
 				theme.draw_item_progress (surface, icon_size, urgent_color, item.Progress);
-			
+
 			return surface;
 		}
-		
+
 		[CCode (instance_pos = -1)]
 		Surface draw_item_background (int width, int height, Surface model, DockItem item)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
 			var shadow_size = position_manager.IconShadowSize * window_scale_factor;
-			
+
 			var draw_value = position_manager.get_draw_value_for_item (item);
 			var icon_size = (int) draw_value.icon_size * window_scale_factor;
 			var icon_surface = item.get_surface (icon_size, icon_size, model);
-			
+
 			Logger.verbose ("DockItem.draw_icon_with_shadow (width = %i, height = %i, shadow_size = %i)", width, height, shadow_size);
 			var surface = new Surface.with_surface (width, height, model);
 			unowned Cairo.Context cr = surface.Context;
 			var shadow_surface = icon_surface.create_mask (0.4, null);
-			
+
 			var xoffset = 0, yoffset = 0;
 			switch (position_manager.Position) {
 			default:
@@ -925,18 +916,18 @@ namespace Plank
 				xoffset = -shadow_size / 4;
 				break;
 			}
-			
+
 			cr.set_source_surface (shadow_surface.Internal, shadow_size + xoffset, shadow_size + yoffset);
 			cr.paint_with_alpha (0.44);
 			surface.gaussian_blur (shadow_size);
-			
+
 			return surface;
 		}
-		
+
 		void draw_indicator_state (Cairo.Context cr, Gdk.Rectangle item_rect, IndicatorState indicator, ItemState item_state)
 		{
 			unowned PositionManager position_manager = controller.position_manager;
-			
+
 			if (indicator_buffer == null) {
 				var indicator_color = get_styled_color ();
 				indicator_color.set_min_sat (0.4);
@@ -948,9 +939,9 @@ namespace Plank
 				urgent_indicator_color.set_sat (1.0);
 				urgent_indicator_buffer = theme.create_indicator (position_manager.IndicatorSize, urgent_indicator_color, item_buffer);
 			}
-			
+
 			unowned Surface indicator_surface = (item_state & ItemState.URGENT) != 0 ? urgent_indicator_buffer : indicator_buffer;
-			
+
 			var x = 0.0, y = 0.0;
 			switch (position_manager.Position) {
 			default:
@@ -971,7 +962,7 @@ namespace Plank
 				y = item_rect.y + item_rect.height / 2.0 - indicator_surface.Height / 2.0;
 				break;
 			}
-			
+
 			if (indicator == IndicatorState.SINGLE) {
 				cr.set_source_surface (indicator_surface.Internal, x, y);
 				cr.paint ();
@@ -981,40 +972,40 @@ namespace Plank
 					x_offset = position_manager.IconSize / 16.0;
 				else
 					y_offset = position_manager.IconSize / 16.0;
-				
+
 				cr.set_source_surface (indicator_surface.Internal, x - x_offset, y - y_offset);
 				cr.paint ();
 				cr.set_source_surface (indicator_surface.Internal, x + x_offset, y + y_offset);
 				cr.paint ();
 			}
 		}
-		
+
 		void draw_urgent_glow (DockItem item, Cairo.Context cr, int64 frame_time)
 		{
 			if ((item.State & ItemState.URGENT) == 0)
 				return;
-			
+
 			var diff = int64.max (0LL, frame_time - item.LastUrgent);
 			if (diff >= theme.GlowTime * 1000)
 				return;
-			
+
 			unowned PositionManager position_manager = controller.position_manager;
 			var x_offset = 0, y_offset = 0;
-			
+
 			if (urgent_glow_buffer == null) {
 				var urgent_color = get_styled_color ();
 				urgent_color.add_hue (theme.UrgentHueShift);
 				urgent_color.set_sat (1.0);
 				urgent_glow_buffer = theme.create_urgent_glow (position_manager.GlowSize, urgent_color, main_buffer);
 			}
-			
+
 			position_manager.get_urgent_glow_position (item, out x_offset, out y_offset);
-			
+
 			cr.set_source_surface (urgent_glow_buffer.Internal, x_offset, y_offset);
 			var opacity = 0.2 + (0.75 * (Math.sin (diff / (double) (theme.GlowPulseTime * 1000) * 2 * Math.PI) + 1) / 2);
 			cr.paint_with_alpha (opacity);
 		}
-		
+
 		Color get_styled_color ()
 		{
 			unowned Gtk.StyleContext context = theme.get_style_context ();
@@ -1022,74 +1013,74 @@ namespace Plank
 			color.set_min_val (90 / (double) uint16.MAX);
 			return color;
 		}
-		
+
 		void hidden_changed ()
 		{
 			force_frame_time_update ();
 			var now = frame_time;
 			var diff = now - last_hide;
 			var time = (theme.FadeOpacity == 1.0 ? theme.HideTime : theme.FadeTime) * 1000;
-			
+
 			if (diff < time)
 				last_hide = now + (diff - time);
 			else
 				last_hide = now;
-			
+
 			if (!screen_is_composited) {
 				controller.position_manager.update_dock_position ();
 				controller.window.update_size_and_position ();
 				return;
 			}
-			
+
 			controller.window.update_icon_regions ();
-			
+
 			animated_draw ();
 		}
-		
+
 		void hovered_changed ()
 		{
 			force_frame_time_update ();
 			var now = frame_time;
 			var diff = now - last_hovered_changed;
 			var time = DOCK_ZOOM_DURATION * 1000;
-			
+
 			if (diff < time)
 				last_hovered_changed = now + (diff - time);
 			else
 				last_hovered_changed = now;
-			
+
 			animated_draw ();
 		}
-		
+
 		public void update_local_cursor (int x, int y)
 		{
 			Gdk.Point new_cursor = { x, y };
 			if (local_cursor == new_cursor)
 				return;
-			
+
 			local_cursor = new_cursor;
-			
+
 			if (screen_is_composited) {
 				zoom_changed = true;
 				animated_draw ();
 			}
 		}
-		
+
 		public void animate_items (Gee.List<DockElement> elements)
 		{
 			if (!screen_is_composited)
 				return;
-			
+
 			foreach (var element in elements) {
 				DockItem? item = (element as DockItem);
 				if (item != null)
 					transient_items.add (item);
 			}
-			
+
 			if (transient_items.size > 0)
 				animated_draw ();
 		}
-		
+
 		/**
 		 * {@inheritDoc}
 		 */
@@ -1100,10 +1091,10 @@ namespace Plank
 				zoom_changed = false;
 				return true;
 			}
-			
+
 			if (frame_time - last_hovered_changed <= DOCK_ZOOM_DURATION * 1000)
 				return true;
-			
+
 			if (theme.FadeOpacity == 1.0) {
 				if (frame_time - last_hide <= theme.HideTime * 1000)
 					return true;
@@ -1111,14 +1102,14 @@ namespace Plank
 				if (frame_time - last_hide <= theme.FadeTime * 1000)
 					return true;
 			}
-			
+
 			if (transient_items.size > 0)
 				return true;
-			
+
 			foreach (var item in current_items)
 				if (item_animation_needed (item, frame_time))
 					return true;
-			
+
 			return false;
 		}
 
@@ -1146,27 +1137,27 @@ namespace Plank
 				return true;
 			if (render_time - item.LastValid <= ITEM_INVALID_DURATION * 1000)
 				return true;
-			
+
 			return false;
 		}
-		
+
 		static int compare_dock_item_position (DockItem i1, DockItem i2)
 		{
 			var p_i1 = i1.Position;
 			var p_i2 = i2.Position;
-			
+
 			if (p_i1 > p_i2)
 				return 1;
-			
+
 			if (p_i1 < p_i2)
 				return -1;
-			
+
 			if (i1.RemoveTime > i2.RemoveTime)
 				return -1;
-			
+
 			return 1;
 		}
-		
+
 		static double easing_bounce (double t, double d, double n)
 			requires (t >= 0.0 && d > 0.0 && n >= 1.0)
 			requires (t <= d)
@@ -1174,11 +1165,11 @@ namespace Plank
 			var p = t / d;
 			return Math.fabs (Math.sin (n * Math.PI * p) * double.min (1.0, (1.0 - p) * (2.0 * n) / (2.0 * n - 1.0)));
 		}
-		
+
 		static unowned string cairo_surface_type_to_string (Cairo.SurfaceType type)
 		{
 			unowned string result;
-			
+
 			switch (type) {
 			case Cairo.SurfaceType.IMAGE: result = "IMAGE"; break;
 			case Cairo.SurfaceType.PDF: result = "PDF"; break;
@@ -1208,7 +1199,7 @@ namespace Plank
 			//case Cairo.SurfaceType.COGL: result = "COGL"; break;
 			default: result = "???"; break;
 			}
-			
+
 			return result;
 		}
 	}

--- a/lib/Drawing/DockTheme.vala
+++ b/lib/Drawing/DockTheme.vala
@@ -27,73 +27,73 @@ namespace Plank
 		const double MIN_INDICATOR_SIZE = 0.0;
 		const double MAX_INDICATOR_SIZE = 10.0;
 		const double MAX_ICON_SHADOW_SIZE = 5.0;
-		
+
 		[Description(nick = "horizontal-padding", blurb = "The padding on the left/right dock edges, in tenths of a percent of IconSize.")]
 		public double HorizPadding { get; set; }
-		
+
 		[Description(nick = "top-padding", blurb = "The padding on the top dock edge, in tenths of a percent of IconSize.")]
 		public double TopPadding { get; set; }
-		
+
 		[Description(nick = "bottom-padding", blurb = "The padding on the bottom dock edge, in tenths of a percent of IconSize.")]
 		public double BottomPadding { get; set; }
-		
+
 		[Description(nick = "item-padding", blurb = "The padding between items on the dock, in tenths of a percent of IconSize.")]
 		public double ItemPadding { get; set; }
-		
+
 		[Description(nick = "indicator-size", blurb = "The size of item indicators, in tenths of a percent of IconSize.")]
 		public double IndicatorSize { get; set; }
-		
+
 		[Description(nick = "icon-shadow-size", blurb = "The size of the icon-shadow behind every item, in tenths of a percent of IconSize.")]
 		public double IconShadowSize { get; set; }
-		
+
 		[Description(nick = "urgent-bounce", blurb = "The height (in percent of IconSize) to bounce an icon when the application sets urgent.")]
 		public double UrgentBounceHeight { get; set; }
-		
+
 		[Description(nick = "launch-bounce", blurb = "The height (in percent of IconSize) to bounce an icon when launching an application.")]
 		public double LaunchBounceHeight { get; set; }
-		
+
 		[Description(nick = "fade-opacity", blurb = "The opacity value (0 to 1) to fade the dock to when hiding it.")]
 		public double FadeOpacity { get; set; }
-		
+
 		[Description(nick = "click-time", blurb = "The amount of time (in ms) for click animations.")]
 		public int ClickTime { get; set; }
-		
+
 		[Description(nick = "urgent-bounce-time", blurb = "The amount of time (in ms) to bounce an urgent icon.")]
 		public int UrgentBounceTime { get; set; }
-		
+
 		[Description(nick = "launch-bounce-time", blurb = "The amount of time (in ms) to bounce an icon when launching an application.")]
 		public int LaunchBounceTime { get; set; }
-		
+
 		[Description(nick = "active-time", blurb = "The amount of time (in ms) for active window indicator animations.")]
 		public int ActiveTime { get; set; }
-		
+
 		[Description(nick = "slide-time", blurb = "The amount of time (in ms) to slide icons into/out of the dock.")]
 		public int SlideTime { get; set; }
-		
+
 		[Description(nick = "fade-time", blurb = "The time (in ms) to fade the dock in/out on a hide (if FadeOpacity is < 1).")]
 		public int FadeTime { get; set; }
-		
+
 		[Description(nick = "hide-time", blurb = "The time (in ms) to slide the dock in/out on a hide (if FadeOpacity is 1).")]
 		public int HideTime { get; set; }
-		
+
 		[Description(nick = "glow-size", blurb = "The size of the urgent glow (shown when dock is hidden), in tenths of a percent of IconSize.")]
 		public int GlowSize { get; set; }
-		
+
 		[Description(nick = "glow-time", blurb = "The total time (in ms) to show the hidden-dock urgent glow.")]
 		public int GlowTime { get; set; }
-		
+
 		[Description(nick = "glow-pulse-time", blurb = "The time (in ms) of each pulse of the hidden-dock urgent glow.")]
 		public int GlowPulseTime { get; set; }
-		
+
 		[Description(nick = "urgent-hue-shift", blurb = "The hue-shift (-180 to 180) of the urgent indicator color.")]
 		public int UrgentHueShift { get; set; }
-		
+
 		[Description(nick = "item-move-time", blurb = "The time (in ms) to move an item to its new position or its addition/removal to/from the dock.")]
 		public int ItemMoveTime { get; set; }
-		
+
 		[Description(nick = "cascade-hide", blurb = "Whether background and icons will unhide/hide with different speeds. The top-border of both will leave/hit the screen-edge at the same time.")]
 		public bool CascadeHide { get; set; }
-		
+
 		[Description(nick = "badge-color", blurb = "The color (RGBA) of the badge displaying urgent count")]
 		public Color BadgeColor { get; set; }
 
@@ -101,7 +101,7 @@ namespace Plank
 		{
 			base.with_name (name);
 		}
-		
+
 		/**
 		 * {@inheritDoc}
 		 */
@@ -134,7 +134,7 @@ namespace Plank
 			CascadeHide = true;
 			BadgeColor = { 0.0, 0.0, 0.0, 0.0 };
 		}
-		
+
 		/**
 		 * Creates a surface for the dock background.
 		 *
@@ -147,31 +147,31 @@ namespace Plank
 		public Surface create_background (int width, int height, Gtk.PositionType position, Surface model)
 		{
 			Logger.verbose ("DockTheme.create_background (width = %i, height = %i)", width, height);
-			
+
 			var surface = new Surface.with_surface (width, height, model);
 			surface.clear ();
-			
+
 			if (width <= 0 || height <= 0)
 				return surface;
-			
+
 			if (position == Gtk.PositionType.BOTTOM) {
 				draw_background (surface);
 				return surface;
 			}
-			
+
 			Surface temp;
 			if (position == Gtk.PositionType.TOP)
 				temp = new Surface.with_surface (width, height, surface);
 			else
 				temp = new Surface.with_surface (height, width, surface);
-			
+
 			draw_background (temp);
-			
+
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			var rotate = 0.0;
 			var x_offset = 0.0, y_offset = 0.0;
-			
+
 			switch (position) {
 			default:
 			case Gtk.PositionType.BOTTOM:
@@ -190,16 +190,16 @@ namespace Plank
 				x_offset = -height;
 				break;
 			}
-			
+
 			cr.save ();
 			cr.rotate (rotate);
 			cr.set_source_surface (temp.Internal, x_offset, y_offset);
 			cr.paint ();
 			cr.restore ();
-			
+
 			return surface;
 		}
-		
+
 		/**
 		 * Creates a surface for an indicator.
 		 *
@@ -211,22 +211,22 @@ namespace Plank
 		public Surface create_indicator (int size, Color color, Surface model)
 		{
 			Logger.verbose ("DockTheme.create_indicator (size = %i)", size);
-			
+
 			var surface = new Surface.with_surface (size, size, model);
 			surface.clear ();
-			
+
 			if (size <= 0)
 				return surface;
-			
+
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			var x = size / 2;
 			var y = x;
-			
+
 			cr.move_to (x, y);
 			cr.arc (x, y, size / 2, 0, Math.PI * 2);
 			cr.close_path ();
-			
+
 			var rg = new Cairo.Pattern.radial (x, y, 0, x, y, size / 2);
 			rg.add_color_stop_rgba (0, 1, 1, 1, 1);
 			rg.add_color_stop_rgba (0.1, color.red, color.green, color.blue, 1);
@@ -234,13 +234,13 @@ namespace Plank
 			rg.add_color_stop_rgba (0.25, color.red, color.green, color.blue, 0.25);
 			rg.add_color_stop_rgba (0.5, color.red, color.green, color.blue, 0.15);
 			rg.add_color_stop_rgba (1.0, color.red, color.green, color.blue, 0.0);
-			
+
 			cr.set_source (rg);
 			cr.fill ();
-			
+
 			return surface;
 		}
-		
+
 		/**
 		 * Creates a surface for an urgent glow.
 		 *
@@ -252,30 +252,30 @@ namespace Plank
 		public Surface create_urgent_glow (int size, Color color, Surface model)
 		{
 			Logger.verbose ("DockTheme.create_urgent_glow (size = %i)", size);
-			
+
 			var surface = new Surface.with_surface (size, size, model);
 			surface.clear ();
-			
+
 			if (size <= 0)
 				return surface;
-			
+
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			var x = size / 2.0;
-			
+
 			cr.move_to (x, x);
 			cr.arc (x, x, size / 2, 0, Math.PI * 2);
 			cr.close_path ();
-			
+
 			var rg = new Cairo.Pattern.radial (x, x, 0, x, x, size / 2);
 			rg.add_color_stop_rgba (0, 1, 1, 1, 1);
 			rg.add_color_stop_rgba (0.33, color.red, color.green, color.blue, 0.66);
 			rg.add_color_stop_rgba (0.66, color.red, color.green, color.blue, 0.33);
 			rg.add_color_stop_rgba (1.0, color.red, color.green, color.blue, 0.0);
-			
+
 			cr.set_source (rg);
 			cr.fill ();
-			
+
 			return surface;
 		}
 
@@ -289,49 +289,50 @@ namespace Plank
 		 * @param opacity the opacity of the glow
 		 * @param pos the dock's position
 		 */
+		[Version (deprecated = true, deprecated_since = "0.12")]
 		public void draw_active_glow (Surface surface, Gdk.Rectangle clip_rect, Gdk.Rectangle rect, Color color, double opacity, Gtk.PositionType pos)
 		{
 			if (opacity <= 0.0 || rect.width <= 0 || rect.height <= 0)
 				return;
-			
+
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			var rotate = 0.0;
 			var xoffset = 0.0, yoffset = 0.0;
-			
+
 			Cairo.Pattern gradient = null;
-			
+
 			switch (pos) {
 			default:
 			case Gtk.PositionType.BOTTOM:
 				xoffset = clip_rect.x;
 				yoffset = clip_rect.y;
-				
+
 				gradient = new Cairo.Pattern.linear (0, rect.y, 0, rect.y + rect.height);
 				break;
 			case Gtk.PositionType.TOP:
 				rotate = Math.PI;
 				xoffset = -clip_rect.x - clip_rect.width;
 				yoffset = -clip_rect.height;
-				
+
 				gradient = new Cairo.Pattern.linear (0, rect.y + rect.height, 0, rect.y);
 				break;
 			case Gtk.PositionType.LEFT:
 				rotate = Math.PI_2;
 				xoffset = clip_rect.y;
 				yoffset = -clip_rect.width;
-				
+
 				gradient = new Cairo.Pattern.linear (rect.x + rect.width, 0, rect.x, 0);
 				break;
 			case Gtk.PositionType.RIGHT:
 				rotate = -Math.PI_2;
 				xoffset = -clip_rect.y - clip_rect.height;
 				yoffset = clip_rect.x;
-				
+
 				gradient = new Cairo.Pattern.linear (rect.x, 0, rect.x + rect.width, 0);
 				break;
 			}
-			
+
 			cr.save ();
 			cr.rotate (rotate);
 			cr.translate (xoffset, yoffset);
@@ -340,20 +341,20 @@ namespace Plank
 			else
 				draw_inner_rect (cr, clip_rect.height, clip_rect.width);
 			cr.restore ();
-			
+
 			cr.set_line_width (LineWidth);
 			cr.clip ();
 
 			gradient.add_color_stop_rgba (0, color.red, color.green, color.blue, 0);
 			gradient.add_color_stop_rgba (1, color.red, color.green, color.blue, 0.6 * opacity);
-			
+
 			cr.rectangle (rect.x, rect.y, rect.width, rect.height);
 			cr.set_source (gradient);
 			cr.fill ();
-			
+
 			cr.reset_clip ();
 		}
-		
+
 		/**
 		 * Draws a badge for an item.
 		 *
@@ -365,12 +366,12 @@ namespace Plank
 		public void draw_item_count (Surface surface, int icon_size, Color color, int64 count)
 		{
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			// Expect the icon to be in the center of the given surface
 			// and adjust the offset accordingly
 			var x = Math.floor ((surface.Width - icon_size) / 2);
 			var y = Math.floor ((surface.Height - icon_size) / 2);
-			
+
 			var badge_color_start = color;
 			badge_color_start.brighten_val (1.0);
 			var badge_color_middle = color;
@@ -383,7 +384,7 @@ namespace Plank
 			var stroke_color_end = color;
 			stroke_color_end.set_sat (0.9);
 			stroke_color_end.darken_val (0.9);
-			
+
 			// FIXME enhance scalability and adjustments depending on icon-size
 			var is_small = icon_size < 32;
 			var is_large = icon_size > 54;
@@ -402,16 +403,16 @@ namespace Plank
 			else
 				x += icon_size - width - 1.5 * line_width;
 			y += line_width + line_width / 2.0;
-			
+
 			cr.set_line_width (line_width);
-			
+
 			Cairo.Pattern stroke, fill;
-			
+
 			if (!is_small) {
 				// draw outline shadow
 				stroke = new Cairo.Pattern.rgba (0.2, 0.2, 0.2, 0.3);
 				draw_rounded_line (cr, x, y, width + line_width, height, true, true, stroke, null);
-				
+
 				// draw filled gradient with outline
 				stroke = new Cairo.Pattern.linear (0, y, 0, y + height);
 				stroke.add_color_stop_rgba (0.2, stroke_color_start.red, stroke_color_start.green, stroke_color_start.blue, 0.8);
@@ -421,40 +422,40 @@ namespace Plank
 				fill.add_color_stop_rgba (0.5, badge_color_middle.red, badge_color_middle.green, badge_color_middle.blue, 1.0);
 				fill.add_color_stop_rgba (0.9, badge_color_end.red, badge_color_end.green, badge_color_end.blue, 1.0);
 				draw_rounded_line (cr, x, y, width, height, true, true, stroke, fill);
-				
+
 				// draw inline highlight
 				stroke = new Cairo.Pattern.rgba (0.9, 0.9, 0.9, 0.1);
 				draw_rounded_line (cr, x + line_width, y + line_width, width - 2 * line_width, height - 2 * line_width, true, true, stroke, null);
 			}
-			
+
 			var layout = new Pango.Layout (Gdk.pango_context_get ());
 			layout.set_width ((int) (width * Pango.SCALE));
 			layout.set_ellipsize (Pango.EllipsizeMode.NONE);
-			
+
 			unowned Gtk.StyleContext style_context = get_style_context ();
 			unowned Pango.FontDescription font_description = style_context.get_font (style_context.get_state ());
 			font_description.set_absolute_size ((int) (height * Pango.SCALE));
 			font_description.set_weight (Pango.Weight.BOLD);
 			layout.set_font_description (font_description);
-			
+
 			layout.set_text (count.to_string (), -1);
 			Pango.Rectangle logical_rect;
 			layout.get_pixel_extents (null, out logical_rect);
-			
+
 			var scale = double.min (1.0, double.min ((width - 2.0 * padding - 2.0 * line_width) / (double) logical_rect.width, (height - 2.0 * padding) / (double) logical_rect.height));
-			
+
 			if (!is_small)
 				cr.set_source_rgba (0.0, 0.0, 0.0, 0.2);
 			else
 				cr.set_source_rgba (0.0, 0.0, 0.0, 0.6);
-			
+
 			cr.move_to (x + Math.floor (width / 2.0 - scale * logical_rect.width / 2.0), y + Math.floor (height / 2.0 - scale * logical_rect.height / 2.0));
-			
+
 			// draw text
 			cr.save ();
 			if (scale < 1)
 				cr.scale (scale, scale);
-			
+
 			cr.set_line_width (line_width);
 			Pango.cairo_layout_path (cr, layout);
 			cr.stroke_preserve ();
@@ -476,17 +477,17 @@ namespace Plank
 		{
 			if (progress < 0)
 				return;
-			
+
 			if (progress > 1.0)
 				progress = 1.0;
-			
+
 			unowned Cairo.Context cr = surface.Context;
-			
+
 			// Expect the icon to be in the center of the given surface
 			// and adjust the offset accordingly
 			var x = Math.floor ((surface.Width - icon_size) / 2);
 			var y = Math.floor ((surface.Height - icon_size) / 2);
-			
+
 			// FIXME enhance scalability and adjustments depending on icon-size
 			var line_width = 1.0;
 			var padding = 4.0;
@@ -494,151 +495,151 @@ namespace Plank
 			var height = Math.floor (double.min (18.0, (int) (0.15 * icon_size)));
 			x += padding;
 			y += icon_size - height - padding;
-			
+
 			cr.set_line_width (line_width);
-			
+
 			Cairo.Pattern stroke, fill;
-			
+
 			// draw the outer stroke
 			stroke = new Cairo.Pattern.linear (0, y, 0, y + height);
 			stroke.add_color_stop_rgba (0.5, 0.5, 0.5, 0.5, 0.1);
 			stroke.add_color_stop_rgba (0.9, 0.8, 0.8, 0.8, 0.4);
 			draw_rounded_line (cr, x + line_width / 2.0, y + line_width / 2.0, width, height, true, true, stroke, null);
-			
+
 			// draw the background
 			x += line_width;
 			y += line_width;
 			width -= 2.0 * line_width;
 			height -= 2.0 * line_width;
-			
+
 			stroke = new Cairo.Pattern.rgba (0.20, 0.20, 0.20, 0.9);
 			fill = new Cairo.Pattern.linear (0, y, 0, y + height);
 			fill.add_color_stop_rgba (0.4, 0.25, 0.25, 0.25, 1.0);
 			fill.add_color_stop_rgba (0.9, 0.35, 0.35, 0.35, 1.0);
 			draw_rounded_line (cr, x + line_width / 2.0, y + line_width / 2.0, width, height, true, true, stroke, fill);
-			
+
 			// draw the finished bar
 			x += line_width;
 			y += line_width;
 			width -= 2.0 * line_width;
 			height -= 2.0 * line_width;
-			
+
 			var finished_width = Math.ceil (progress * width);
 			stroke = new Cairo.Pattern.rgba (0.8, 0.8, 0.8, 1.0);
 			fill = new Cairo.Pattern.rgba (0.9, 0.9, 0.9, 1.0);
-			
+
 			// Mirror progress-bar for RTL environments
 			if (Gtk.Widget.get_default_direction () == Gtk.TextDirection.RTL)
 				draw_rounded_line (cr, x + line_width / 2.0 + width - finished_width, y + line_width / 2.0, finished_width, height, true, true, stroke, fill);
 			else
 				draw_rounded_line (cr, x + line_width / 2.0, y + line_width / 2.0, finished_width, height, true, true, stroke, fill);
 		}
-		
+
 		/**
 		 * {@inheritDoc}
 		 */
 		protected override void verify (string prop)
 		{
 			base.verify (prop);
-			
+
 			switch (prop) {
 			case "HorizPadding":
 				break;
-			
+
 			case "TopPadding":
 				break;
-			
+
 			case "BottomPadding":
 				if (BottomPadding < 0)
 					BottomPadding = 0;
 				break;
-			
+
 			case "ItemPadding":
 				if (ItemPadding < 0)
 					ItemPadding = 0;
 				break;
-			
+
 			case "IndicatorSize":
 				if (IndicatorSize < MIN_INDICATOR_SIZE)
 					IndicatorSize = MIN_INDICATOR_SIZE;
 				else if (IndicatorSize > MAX_INDICATOR_SIZE)
 					IndicatorSize = MAX_INDICATOR_SIZE;
 				break;
-			
+
 			case "IconShadowSize":
 				if (IconShadowSize < 0)
 					IconShadowSize = 0;
 				else if (IconShadowSize > MAX_ICON_SHADOW_SIZE)
 					IconShadowSize = MAX_ICON_SHADOW_SIZE;
 				break;
-			
+
 			case "UrgentBounceHeight":
 				if (UrgentBounceHeight < 0)
 					UrgentBounceHeight = 0;
 				break;
-			
+
 			case "LaunchBounceHeight":
 				if (LaunchBounceHeight < 0)
 					LaunchBounceHeight = 0;
 				break;
-			
+
 			case "FadeOpacity":
 				if (FadeOpacity < 0)
 					FadeOpacity = 0;
 				else if (FadeOpacity > 1)
 					FadeOpacity = 1;
 				break;
-			
+
 			case "ClickTime":
 				if (ClickTime < 0)
 					ClickTime = 0;
 				break;
-			
+
 			case "UrgentBounceTime":
 				if (UrgentBounceTime < 0)
 					UrgentBounceTime = 0;
 				break;
-			
+
 			case "LaunchBounceTime":
 				if (LaunchBounceTime < 0)
 					LaunchBounceTime = 0;
 				break;
-			
+
 			case "ActiveTime":
 				if (ActiveTime < 0)
 					ActiveTime = 0;
 				break;
-			
+
 			case "SlideTime":
 				if (SlideTime < 0)
 					SlideTime = 0;
 				break;
-			
+
 			case "FadeTime":
 				if (FadeTime < 0)
 					FadeTime = 0;
 				break;
-			
+
 			case "HideTime":
 				if (HideTime < 0)
 					HideTime = 0;
 				break;
-			
+
 			case "GlowSize":
 				if (GlowSize < 0)
 					GlowSize = 0;
 				break;
-			
+
 			case "GlowTime":
 				if (GlowTime < 0)
 					GlowTime = 0;
 				break;
-			
+
 			case "GlowPulseTime":
 				if (GlowPulseTime < 0)
 					GlowPulseTime = 0;
 				break;
-			
+
 			case "UrgentHueShift":
 				if (UrgentHueShift < -180)
 					UrgentHueShift = -180;


### PR DESCRIPTION
Since now GTK window styling has improved, having a `backdrop` distinction between inactive and active windows, this dock glow is not needed anymore.