### PR TITLE
Meson: bump minimum version to 0.50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('plank',
 	'c', 'vala',
 	version: '0.11.89',
-	meson_version: '>= 0.49.0',
+	meson_version: '>= 0.50.0',
 	license: 'GPL3',
 )
 


### PR DESCRIPTION
Fixes build warnings like:

```
WARNING: Project specifies a minimum meson_version '>= 0.49.0' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}
```