### PR TITLE
Add context menu

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,13 +13,15 @@ gio_unix_dep = dependency('gio-unix-2.0')
 glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')
 gtk_dep = dependency('gtk4')
+granite_dep = dependency('granite-7')
 
 dependencies = [
     gio_dep,
     gio_unix_dep,
     glib_dep,
     gobject_dep,
-    gtk_dep
+    gtk_dep,
+    granite_dep
 ]
 
 meson.add_install_script('meson/post_install.py')

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -31,7 +31,7 @@ public class Dock.Launcher : Gtk.Button {
         windows = new GLib.List<AppWindow> ();
         get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-        var pinned_menu_item = new MenuItem (null, "win." + app_info.get_id () + "pinned");
+        var pinned_menu_item = new MenuItem (null, null);
         pinned_menu_item.set_attribute_value ("custom", "pinned-item");
 
         var close_menu_item = new MenuItem (null, null);
@@ -100,7 +100,7 @@ public class Dock.Launcher : Gtk.Button {
         add_controller (gesture_click);
         gesture_click.released.connect (popover.popup);
 
-        clicked.connect (() => launch());
+        clicked.connect (() => launch ());
 
         close_button.clicked.connect (() => {
             // TODO

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -75,6 +75,7 @@ public class Dock.Launcher : Gtk.Button {
         close_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
 
         popover = new Gtk.PopoverMenu.from_model (model) {
+            autohide = true,
             position = TOP
         };
         popover.set_parent (this);

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -95,6 +95,7 @@ public class Dock.Launcher : Gtk.Button {
         } catch (Error e) {
             critical (e.message);
         }
+
         Timeout.add (400, () => {
             remove_css_class ("bounce");
 

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -11,6 +11,9 @@ public class Dock.Launcher : Gtk.Button {
 
     private static Gtk.CssProvider css_provider;
 
+    private Gtk.Button close_button;
+    private Gtk.PopoverMenu popover;
+
     public Launcher (GLib.DesktopAppInfo app_info) {
         Object (app_info: app_info);
     }
@@ -28,6 +31,56 @@ public class Dock.Launcher : Gtk.Button {
         windows = new GLib.List<AppWindow> ();
         get_style_context ().add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
+        var pinned_menu_item = new MenuItem (null, "win." + app_info.get_id () + "pinned");
+        pinned_menu_item.set_attribute_value ("custom", "pinned-item");
+
+        var close_menu_item = new MenuItem (null, null);
+        close_menu_item.set_attribute_value ("custom", "close-item");
+
+        var action_section = new Menu ();
+        foreach (var action in app_info.list_actions ()) {
+            action_section.append (
+                app_info.get_action_name (action),
+                MainWindow.ACTION_PREFIX + MainWindow.LAUNCHER_ACTION_TEMPLATE.printf (app_info.get_id (), action)
+            );
+        }
+
+        var model = new Menu ();
+        model.append_item (pinned_menu_item);
+        model.append_item (close_menu_item); // Placeholder, currently doesn't work
+        if (action_section.get_n_items () > 0) {
+            model.append_section (null, action_section);
+        }
+
+        var pinned_label = new Gtk.Label ("Keep in Dock") {
+            xalign = 0,
+            hexpand = true
+        };
+
+        var pinned_check_button = new Gtk.CheckButton ();
+
+        var pinned_box = new Gtk.Box (HORIZONTAL, 3);
+        pinned_box.append (pinned_label);
+        pinned_box.append (pinned_check_button);
+
+        var pinned_button = new Gtk.ToggleButton () {
+            child = pinned_box
+        };
+        pinned_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+
+        close_button = new Gtk.Button () {
+            visible = false,
+            child = new Gtk.Label (_("Close")) { halign = START }
+        };
+        close_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
+
+        popover = new Gtk.PopoverMenu.from_model (model) {
+            position = TOP
+        };
+        popover.set_parent (this);
+        popover.add_child (pinned_button, "pinned-item");
+        popover.add_child (close_button, "close-item");
+
         var image = new Gtk.Image () {
             gicon = app_info.get_icon ()
         };
@@ -36,33 +89,59 @@ public class Dock.Launcher : Gtk.Button {
         child = image;
         tooltip_text = app_info.get_display_name ();
 
-        clicked.connect (() => {
-            try {
-                add_css_class ("bounce");
+        bind_property ("pinned", pinned_button, "active", BIDIRECTIONAL | SYNC_CREATE);
+        pinned_button.bind_property ("active", pinned_check_button, "active", SYNC_CREATE);
 
-                var context = Gdk.Display.get_default ().get_app_launch_context ();
-                context.set_timestamp (Gdk.CURRENT_TIME);
+        notify["pinned"].connect (() => ((MainWindow) get_root ()).sync_pinned ());
 
+        var gesture_click = new Gtk.GestureClick () {
+            button = Gdk.BUTTON_SECONDARY
+        };
+        add_controller (gesture_click);
+        gesture_click.released.connect (popover.popup);
+
+        clicked.connect (() => launch());
+
+        close_button.clicked.connect (() => {
+            // TODO
+        });
+    }
+
+    ~Launcher () {
+        popover.unparent ();
+        popover.dispose ();
+    }
+
+    public void launch (string? action = null) {
+        try {
+            add_css_class ("bounce");
+
+            var context = Gdk.Display.get_default ().get_app_launch_context ();
+            context.set_timestamp (Gdk.CURRENT_TIME);
+
+            if (action != null) {
+                app_info.launch_action (action, context);
+            } else {
                 app_info.launch (null, context);
-            } catch (Error e) {
-                critical (e.message);
             }
-            Timeout.add (400, () => {
-                remove_css_class ("bounce");
+        } catch (Error e) {
+            critical (e.message);
+        }
+        Timeout.add (400, () => {
+            remove_css_class ("bounce");
 
-                return Source.REMOVE;
-            });
-
+            return Source.REMOVE;
         });
     }
 
     public void update_windows (owned GLib.List<AppWindow>? new_windows) {
         if (new_windows == null) {
             windows = new GLib.List<AppWindow> ();
-            return;
+        } else {
+            windows = (owned) new_windows;
         }
 
-        windows = (owned) new_windows;
+        close_button.visible = !windows.is_empty ();
     }
 
     public AppWindow? find_window (uint64 window_uid) {

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -38,11 +38,11 @@ public class Dock.Launcher : Gtk.Button {
             );
         }
 
-        var pinned_menu_item = new MenuItem (null, null);
-        pinned_menu_item.set_attribute_value ("custom", "pinned-item");
-
         var pinned_section = new Menu ();
-        pinned_section.append_item (pinned_menu_item);
+        pinned_section.append (
+            _("Keep in Dock"),
+            MainWindow.ACTION_PREFIX + MainWindow.LAUNCHER_PINNED_ACTION_TEMPLATE.printf (app_info.get_id ())
+        );
 
         var model = new Menu ();
         if (action_section.get_n_items () > 0) {
@@ -50,28 +50,11 @@ public class Dock.Launcher : Gtk.Button {
         }
         model.append_section (null, pinned_section);
 
-        var pinned_label = new Gtk.Label ("Keep in Dock") {
-            xalign = 0,
-            hexpand = true
-        };
-
-        var pinned_check_button = new Gtk.CheckButton ();
-
-        var pinned_box = new Gtk.Box (HORIZONTAL, 3);
-        pinned_box.append (pinned_label);
-        pinned_box.append (pinned_check_button);
-
-        var pinned_button = new Gtk.ToggleButton () {
-            child = pinned_box
-        };
-        pinned_button.add_css_class (Granite.STYLE_CLASS_MENUITEM);
-
         popover = new Gtk.PopoverMenu.from_model (model) {
             autohide = true,
             position = TOP
         };
         popover.set_parent (this);
-        popover.add_child (pinned_button, "pinned-item");
 
         var image = new Gtk.Image () {
             gicon = app_info.get_icon ()
@@ -80,9 +63,6 @@ public class Dock.Launcher : Gtk.Button {
 
         child = image;
         tooltip_text = app_info.get_display_name ();
-
-        bind_property ("pinned", pinned_button, "active", BIDIRECTIONAL | SYNC_CREATE);
-        pinned_button.bind_property ("active", pinned_check_button, "active", SYNC_CREATE);
 
         notify["pinned"].connect (() => ((MainWindow) get_root ()).sync_pinned ());
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -145,16 +145,14 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
     public void sync_pinned () {
         string[] new_pinned_ids = {};
 
-        Launcher child = (Launcher) box.get_first_child ();
+        unowned Launcher child = (Launcher) box.get_first_child ();
         while (child != null) {
-            if (child.pinned) {
-                new_pinned_ids += child.app_info.get_id ();
-            }
-
-            var current_child = child;
+            unowned var current_child = child;
             child = (Launcher) child.get_next_sibling ();
 
-            if (!current_child.pinned && current_child.windows.is_empty ()) {
+            if (current_child.pinned) {
+                new_pinned_ids += current_child.app_info.get_id ();
+            } else if (!current_child.pinned && current_child.windows.is_empty ()) {
                 remove_launcher (current_child);
             }
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -6,6 +6,7 @@
 public class Dock.MainWindow : Gtk.ApplicationWindow {
     // First %s is the app id second %s the action name
     public const string LAUNCHER_ACTION_TEMPLATE = "%s.%s";
+    // %s is the app id
     public const string LAUNCHER_PINNED_ACTION_TEMPLATE = "%s-pinned";
     public const string ACTION_GROUP_PREFIX = "win";
     public const string ACTION_PREFIX = ACTION_GROUP_PREFIX + ".";

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -6,6 +6,7 @@
 public class Dock.MainWindow : Gtk.ApplicationWindow {
     // First %s is the app id second %s the action name
     public const string LAUNCHER_ACTION_TEMPLATE = "%s.%s";
+    public const string LAUNCHER_PINNED_ACTION_TEMPLATE = "%s-pinned";
     public const string ACTION_GROUP_PREFIX = "win";
     public const string ACTION_PREFIX = ACTION_GROUP_PREFIX + ".";
 
@@ -72,11 +73,22 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
         unowned var app_id = app_info.get_id ();
         app_to_launcher.insert (app_id, launcher);
         box.append (launcher);
+
+        var pinned_action = new SimpleAction.stateful (
+            LAUNCHER_PINNED_ACTION_TEMPLATE.printf (app_id),
+            null,
+            new Variant.boolean (launcher.pinned)
+        );
+        launcher.notify["pinned"].connect (() => pinned_action.set_state (launcher.pinned));
+        pinned_action.change_state.connect ((new_state) => launcher.pinned = (bool) new_state);
+        add_action (pinned_action);
+
         foreach (var action in app_info.list_actions ()) {
             var simple_action = new SimpleAction (LAUNCHER_ACTION_TEMPLATE.printf (app_id, action), null);
             simple_action.activate.connect (() => launcher.launch (action));
             add_action (simple_action);
         }
+
         return app_to_launcher[app_id];
     }
 


### PR DESCRIPTION
- Keep in Dock
- Launch with desktop actions
- ~It has a close button that shows up when there are open windows but it doesn't do anything because AFAIK there currently isn't a way to close other applications~

Compared to the plank menu it now has an arrow that's pointing to the icon, should we keep it? 
The popover currently doesn't close when clicking outside the dock which [is a X Server bug](https://gitlab.gnome.org/GNOME/gtk/-/issues/3502).

Fixes #55
Fixes #86 