### PR TITLE
Integrate with gala window spread

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -23,4 +23,5 @@ public interface Dock.DesktopIntegration : GLib.Object {
 
     public abstract RunningApplication[] get_running_applications () throws GLib.DBusError, GLib.IOError;
     public abstract Window[] get_windows () throws GLib.DBusError, GLib.IOError;
+    public abstract void show_windows_for (string app_id) throws GLib.DBusError, GLib.IOError;
 }

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -239,8 +239,10 @@ public class Dock.Launcher : Gtk.Button {
 
             if (action != null) {
                 app_info.launch_action (action, context);
-            } else {
+            } else if (windows.length () <= 1) {
                 app_info.launch (null, context);
+            } else if (LauncherManager.get_default ().desktop_integration != null) {
+                LauncherManager.get_default ().desktop_integration.show_windows_for (app_info.get_id ());
             }
         } catch (Error e) {
             critical (e.message);

--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -12,9 +12,9 @@
     }
 
     public Launcher? added_launcher { get; set; default = null; }
+    public Dock.DesktopIntegration? desktop_integration { get; private set; }
 
     private List<Launcher> launchers; //Only used to keep track of launcher indices
-    private Dock.DesktopIntegration desktop_integration;
     private GLib.HashTable<unowned string, Dock.Launcher> app_to_launcher;
 
     static construct {


### PR DESCRIPTION
Launch the gala window spread when more than one window is open and the Launcher is clicked.

Requires elementary/gala#1833