### PR TITLE
Rules: enable systemd service

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,10 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --with systemd
 
+override_dh_systemd_enable:
+	dh_systemd_enable -pio.elementary.dock
+
+override_dh_systemd_start:
+	dh_systemd_start -pio.elementary.dock


### PR DESCRIPTION
Taken from https://github.com/elementary/switchboard-plug-parental-controls/blob/deb-packaging/debian/rules

Mabye fixes #213 