### PR TITLE
Focus window on click

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -74,8 +74,10 @@ public class Dock.App : Object {
 
             if (action != null) {
                 app_info.launch_action (action, context);
-            } else if (windows.length () <= 1) {
+            } else if (windows.length () == 0) {
                 app_info.launch (null, context);
+            } else if (windows.length () == 1) {
+                LauncherManager.get_default ().desktop_integration.focus_window.begin (windows.first ().data.uid);
             } else if (LauncherManager.get_default ().desktop_integration != null) {
                 LauncherManager.get_default ().desktop_integration.show_windows_for (app_info.get_id ());
             }

--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -24,4 +24,5 @@ public interface Dock.DesktopIntegration : GLib.Object {
     public abstract RunningApplication[] get_running_applications () throws GLib.DBusError, GLib.IOError;
     public abstract Window[] get_windows () throws GLib.DBusError, GLib.IOError;
     public abstract void show_windows_for (string app_id) throws GLib.DBusError, GLib.IOError;
+    public abstract async void focus_window (uint64 uid) throws GLib.DBusError, GLib.IOError;
 }


### PR DESCRIPTION
For apps that aren't doing single instance management (e.g. gnome calculator i think) or open new windows on repeated activations (e.g. firefox i think) currently clicking the launcher will launch a new instance/window. This PR will activate the open window instead. 
If multiple windows are open the spread is shown like before.