### PR TITLE
Do DBus calls asynchronously

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -21,8 +21,8 @@ public interface Dock.DesktopIntegration : GLib.Object {
     public signal void running_applications_changed ();
     public signal void windows_changed ();
 
-    public abstract RunningApplication[] get_running_applications () throws GLib.DBusError, GLib.IOError;
-    public abstract Window[] get_windows () throws GLib.DBusError, GLib.IOError;
-    public abstract void show_windows_for (string app_id) throws GLib.DBusError, GLib.IOError;
+    public abstract async RunningApplication[] get_running_applications () throws GLib.DBusError, GLib.IOError;
+    public abstract async Window[] get_windows () throws GLib.DBusError, GLib.IOError;
+    public abstract async void show_windows_for (string app_id) throws GLib.DBusError, GLib.IOError;
     public abstract async void focus_window (uint64 uid) throws GLib.DBusError, GLib.IOError;
 }

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -149,9 +149,9 @@ public class Dock.Launcher : Gtk.Button {
 
         var scroll_controller = new Gtk.EventControllerScroll (VERTICAL);
         add_controller (scroll_controller);
-        scroll_controller.scroll_begin.connect (() => app.next_window (false));
+        scroll_controller.scroll_begin.connect (() => app.next_window.begin (false));
         scroll_controller.scroll.connect ((dx, dy) => {
-            app.next_window (dy > 0);
+            app.next_window.begin (dy > 0);
             return Gdk.EVENT_STOP;
         });
 

--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -110,7 +110,7 @@
                     desktop_integration = GLib.Bus.get_proxy.end (res);
                     desktop_integration.windows_changed.connect (sync_windows);
 
-                    sync_windows ();
+                    sync_windows.begin ();
                 } catch (GLib.Error e) {
                     critical (e.message);
                 }
@@ -224,10 +224,10 @@
         }
     }
 
-    public void sync_windows () requires (desktop_integration != null) {
+    public async void sync_windows () requires (desktop_integration != null) {
         DesktopIntegration.Window[] windows;
         try {
-            windows = desktop_integration.get_windows ();
+            windows = yield desktop_integration.get_windows ();
         } catch (Error e) {
             critical (e.message);
             return;


### PR DESCRIPTION
Sometimes it happens that a DBus call freezes (?) which makes the app unresponsive. This will make all DBus calls asynchronous so that if that happens it will just eventually timeout.