### PR TITLE
Launcher: Improve bounce animation

### DIFF
--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -233,6 +233,10 @@ public class Dock.Launcher : Gtk.Button {
     }
 
     private void animate_launch () {
+        if (bounce_up.state == PLAYING || bounce_down.state == PLAYING) {
+            return;
+        }
+
         bounce_up.value_to = -0.5 * overlay.get_height ();
         bounce_down.value_from = bounce_up.value_to;
 


### PR DESCRIPTION
Currently instead of going up and then down while ending with a bounce the launcher "jumps" up and then only goes down and bounces. This PR fixes it and makes the launcher go up with an easing and the as before go down and bounce.