### PR TITLE
Revert "Rules: enable systemd service"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,5 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with systemd
+	dh $@
 
-override_dh_systemd_enable:
-	dh_systemd_enable -pio.elementary.dock
-
-override_dh_systemd_start:
-	dh_systemd_start -pio.elementary.dock


### PR DESCRIPTION
Reverts elementary/dock#214

The systemd unit file is removed in #234