### PR TITLE
Some move after move glitch fixes

### DIFF
--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -274,7 +274,7 @@
     public void move_launcher_after (Launcher source, int target_index) {
         int source_index = launchers.index (source);
 
-        move (source, get_launcher_size () * target_index, 0);
+        source.animate_move (get_launcher_size () * target_index);
 
         bool right = source_index > target_index;
 


### PR DESCRIPTION
When you would reorder a launcher e.g. from the far right to the far left and then do something so that reposition launchers would be called (e.g. launch an app that's not pinned, remove a pinned app, etc.) the launcher that was moved would animate a move from its original position to its current position even though it shouldn't move/animate at all. With this we make sure that we move only via the launchers animate_move so that its current_pos stays in sync with its actual current x