### PR TITLE
Allow launching apps via keyboard shortcuts

### DIFF
--- a/data/dock.gschema.xml
+++ b/data/dock.gschema.xml
@@ -27,4 +27,51 @@
       <description>An ordered array of app id's to show as launchers</description>
     </key>
   </schema>
+  <schema path="/io/elementary/dock/keybindings/" id="io.elementary.dock.keybindings">
+    <key type="as" name="launch-dock-1">
+      <default><![CDATA[['<Super>1']]]></default>
+      <summary>Launch the first dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-2">
+      <default><![CDATA[['<Super>2']]]></default>
+      <summary>Launch the second dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-3">
+      <default><![CDATA[['<Super>3']]]></default>
+      <summary>Launch the third dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-4">
+      <default><![CDATA[['<Super>4']]]></default>
+      <summary>Launch the fourth dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-5">
+      <default><![CDATA[['<Super>5']]]></default>
+      <summary>Launch the fith dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-6">
+      <default><![CDATA[['<Super>6']]]></default>
+      <summary>Launch the sixth dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-7">
+      <default><![CDATA[['<Super>7']]]></default>
+      <summary>Launch the seventh dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-8">
+      <default><![CDATA[['<Super>8']]]></default>
+      <summary>Launch the eigth dock item</summary>
+      <description></description>
+    </key>
+    <key type="as" name="launch-dock-9">
+      <default><![CDATA[['<Super>9']]]></default>
+      <summary>Launch the nineth dock item</summary>
+      <description></description>
+    </key>
+  </schema>
 </schemalist>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -25,6 +25,7 @@ public class Dock.Application : Gtk.Application {
         base.startup ();
 
         Granite.init ();
+        ShellKeyGrabber.init ();
 
         unowned var granite_settings = Granite.Settings.get_default ();
         unowned var gtk_settings = Gtk.Settings.get_default ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,21 +4,11 @@
  */
 
 public class Dock.Application : Gtk.Application {
-    private const string LAUNCH_INDEX = "launch-index";
-
-    private const OptionEntry[] OPTIONS = {
-        { LAUNCH_INDEX, 'i', OptionFlags.NONE, OptionArg.INT, null, "Launch the app that's currently at the given index. Should only be used if dock is already running", "INT" },
-    };
 
     public Application () {
         Object (
-            application_id: "io.elementary.dock",
-            flags: ApplicationFlags.HANDLES_COMMAND_LINE
+            application_id: "io.elementary.dock"
         );
-    }
-
-    construct {
-        add_main_option_entries (OPTIONS);
     }
 
     protected override void startup () {
@@ -35,20 +25,6 @@ public class Dock.Application : Gtk.Application {
         );
 
         gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
-    }
-
-    protected override int command_line (ApplicationCommandLine command_line) {
-        var options = command_line.get_options_dict ();
-
-        if (LAUNCH_INDEX in options) {
-            // Cast to int to automatically get the int from the variant and then to uint for our index
-            // I like how this looks so I left it instead of something more expressive like get_int32 :P
-            LauncherManager.get_default ().launch ((uint)(int) options.lookup_value (LAUNCH_INDEX, VariantType.INT32));
-        } else {
-            activate ();
-        }
-
-        return 0;
     }
 
     protected override void activate () {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,11 +4,8 @@
  */
 
 public class Dock.Application : Gtk.Application {
-
     public Application () {
-        Object (
-            application_id: "io.elementary.dock"
-        );
+        Object (application_id: "io.elementary.dock");
     }
 
     protected override void startup () {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,8 +4,21 @@
  */
 
 public class Dock.Application : Gtk.Application {
+    private const string LAUNCH_INDEX = "launch-index";
+
+    private const OptionEntry[] OPTIONS = {
+        { LAUNCH_INDEX, 'i', OptionFlags.NONE, OptionArg.INT, null, "Launch the app that's currently at the given index. Should only be used if dock is already running", "INT" },
+    };
+
     public Application () {
-        Object (application_id: "io.elementary.dock");
+        Object (
+            application_id: "io.elementary.dock",
+            flags: ApplicationFlags.HANDLES_COMMAND_LINE
+        );
+    }
+
+    construct {
+        add_main_option_entries (OPTIONS);
     }
 
     protected override void startup () {
@@ -21,6 +34,20 @@ public class Dock.Application : Gtk.Application {
         );
 
         gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
+    }
+
+    protected override int command_line (ApplicationCommandLine command_line) {
+        var options = command_line.get_options_dict ();
+
+        if (LAUNCH_INDEX in options) {
+            // Cast to int to automatically get the int from the variant and then to uint for our index
+            // I like how this looks so I left it instead of something more expressive like get_int32 :P
+            LauncherManager.get_default ().launch ((uint)(int) options.lookup_value (LAUNCH_INDEX, VariantType.INT32));
+        } else {
+            activate ();
+        }
+
+        return 0;
     }
 
     protected override void activate () {

--- a/src/DBus/ShellKeyGrabber.vala
+++ b/src/DBus/ShellKeyGrabber.vala
@@ -69,7 +69,6 @@ public interface ShellKeyGrabber : GLib.Object {
     private static async void on_watch () {
         try {
             instance = yield Bus.get_proxy (SESSION, "org.gnome.Shell", "/org/gnome/Shell");
-            warning ("GOT PROXY");
             setup_grabs ();
         } catch (Error e) {
             warning ("Failed to connect to bus for keyboard shortcut grabs: %s", e.message);

--- a/src/DBus/ShellKeyGrabber.vala
+++ b/src/DBus/ShellKeyGrabber.vala
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
+ */
+
 /**
  * ActionMode:
  * @NONE: block action

--- a/src/DBus/ShellKeyGrabber.vala
+++ b/src/DBus/ShellKeyGrabber.vala
@@ -1,0 +1,120 @@
+/**
+ * ActionMode:
+ * @NONE: block action
+ * @NORMAL: allow action when in window mode, e.g. when the focus is in an application window
+ * @OVERVIEW: allow action while the overview is active
+ * @LOCK_SCREEN: allow action when the screen is locked, e.g. when the screen shield is shown
+ * @UNLOCK_SCREEN: allow action in the unlock dialog
+ * @LOGIN_SCREEN: allow action in the login screen
+ * @SYSTEM_MODAL: allow action when a system modal dialog (e.g. authentification or session dialogs) is open
+ * @LOOKING_GLASS: allow action in looking glass
+ * @POPUP: allow action while a shell menu is open
+ */
+
+[Flags]
+public enum ActionMode {
+    NONE = 0,
+    NORMAL = 1 << 0,
+    OVERVIEW = 1 << 1,
+    LOCK_SCREEN = 1 << 2,
+    UNLOCK_SCREEN = 1 << 3,
+    LOGIN_SCREEN = 1 << 4,
+    SYSTEM_MODAL = 1 << 5,
+    LOOKING_GLASS = 1 << 6,
+    POPUP = 1 << 7,
+}
+
+[Flags]
+public enum Meta.KeyBindingFlags {
+    NONE = 0,
+    PER_WINDOW = 1 << 0,
+    BUILTIN = 1 << 1,
+    IS_REVERSED = 1 << 2,
+    NON_MASKABLE = 1 << 3,
+    IGNORE_AUTOREPEAT = 1 << 4,
+}
+
+public struct Accelerator {
+    public string name;
+    public ActionMode mode_flags;
+    public Meta.KeyBindingFlags grab_flags;
+}
+
+[DBus (name = "org.gnome.Shell")]
+public interface ShellKeyGrabber : GLib.Object {
+    public abstract signal void accelerator_activated (uint action, GLib.HashTable<string, GLib.Variant> parameters_dict);
+
+    public abstract uint grab_accelerator (string accelerator, ActionMode mode_flags, Meta.KeyBindingFlags grab_flags) throws GLib.DBusError, GLib.IOError;
+    public abstract uint[] grab_accelerators (Accelerator[] accelerators) throws GLib.DBusError, GLib.IOError;
+    public abstract bool ungrab_accelerator (uint action) throws GLib.DBusError, GLib.IOError;
+    public abstract bool ungrab_accelerators (uint[] actions) throws GLib.DBusError, GLib.IOError;
+
+    private static Settings settings;
+    private static ShellKeyGrabber? instance;
+
+    private static HashTable<uint, int> saved_action_ids;
+
+    public static void init () {
+        settings = new Settings ("io.elementary.dock.keybindings");
+        saved_action_ids = new HashTable<uint, int> (null, null);
+
+        settings.changed.connect (() => {
+            ungrab_keybindings ();
+            setup_grabs ();
+        });
+
+        Bus.watch_name (BusType.SESSION, "org.gnome.Shell", BusNameWatcherFlags.NONE, () => on_watch.begin (), () => instance = null);
+    }
+
+    private static async void on_watch () {
+        try {
+            instance = yield Bus.get_proxy (SESSION, "org.gnome.Shell", "/org/gnome/Shell");
+            warning ("GOT PROXY");
+            setup_grabs ();
+        } catch (Error e) {
+            warning ("Failed to connect to bus for keyboard shortcut grabs: %s", e.message);
+        }
+    }
+
+    private static void setup_grabs () requires (instance != null) {
+        for (int i = 1; i <= 9; i++) {
+            var keybindings = settings.get_strv ("launch-dock-%d".printf (i));
+            Accelerator[] accelerators = {};
+            for (int j = 0; j < keybindings.length; j++) {
+                accelerators += Accelerator () {
+                    name = keybindings[j],
+                    mode_flags = ActionMode.NONE,
+                    grab_flags = Meta.KeyBindingFlags.NONE
+                };
+
+                try {
+                    foreach (var id in instance.grab_accelerators (accelerators)) {
+                        saved_action_ids[id] = i;
+                    }
+                } catch (Error e) {
+                    critical ("Couldn't grab accelerators: %s", e.message);
+                }
+            }
+        }
+
+        instance.accelerator_activated.connect (on_accelerator_activated);
+    }
+
+    private static void on_accelerator_activated (uint action, GLib.HashTable<string, GLib.Variant> parameters_dict) {
+        if (!(action in saved_action_ids)) {
+            return;
+        }
+
+        Dock.LauncherManager.get_default ().launch (saved_action_ids[action]);
+    }
+
+    private static void ungrab_keybindings () requires (instance != null) {
+        var actions = saved_action_ids.get_keys_as_array ();
+
+        try {
+            instance.ungrab_accelerators (actions);
+        } catch (Error e) {
+            critical ("Couldn't ungrab accelerators: %s", e.message);
+        }
+    }
+}

--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -313,8 +313,12 @@
     }
 
     public void launch (uint index) {
+        if (index < 1 || index > launchers.length ()) {
+            return;
+        }
+
         var context = Gdk.Display.get_default ().get_app_launch_context ();
-        launchers.nth (index).data.app.launch (context);
+        launchers.nth (index - 1).data.app.launch (context);
     }
 
     public void add_launcher_for_id (string app_id) {

--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -312,6 +312,11 @@
         settings.set_strv ("launchers", new_pinned_ids);
     }
 
+    public void launch (uint index) {
+        var context = Gdk.Display.get_default ().get_app_launch_context ();
+        launchers.nth (index).data.app.launch (context);
+    }
+
     public void add_launcher_for_id (string app_id) {
         if (app_id in id_to_app) {
             id_to_app[app_id].pinned = true;

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ sources = [
     'MainWindow.vala',
     'PoofPopover.vala',
     'DBus' / 'ItemInterface.vala',
+    'DBus' / 'ShellKeyGrabber.vala',
     'DBus' / 'SwitcherooControl.vala',
     'DBus' / 'Unity.vala'
 ]


### PR DESCRIPTION
Fixes #66 

This will now grab the accelerators via DBus as suggested by @lenemter. I'd leave the commandline option still in there since it might come in handy in some custom scripts/commands people might want to do. But if we'd rather remove it that's fine to.