### PR TITLE
gschema: Add Files to dock

### DIFF
--- a/data/dock.gschema.xml
+++ b/data/dock.gschema.xml
@@ -22,7 +22,7 @@
     </key>
 
     <key type="as" name="launchers">
-      <default>['gala-multitaskingview.desktop', 'org.gnome.Epiphany.desktop', 'io.elementary.mail.desktop', 'io.elementary.tasks.desktop', 'io.elementary.calendar.desktop', 'io.elementary.music.desktop', 'io.elementary.videos.desktop', 'io.elementary.photos.desktop', 'io.elementary.settings.desktop', 'io.elementary.appcenter.desktop']</default>
+      <default>['gala-multitaskingview.desktop', 'io.elementary.files.desktop', 'org.gnome.Epiphany.desktop', 'io.elementary.mail.desktop', 'io.elementary.tasks.desktop', 'io.elementary.calendar.desktop', 'io.elementary.music.desktop', 'io.elementary.videos.desktop', 'io.elementary.photos.desktop', 'io.elementary.settings.desktop', 'io.elementary.appcenter.desktop']</default>
       <summary>An ordered array of app id's to show as launchers</summary>
       <description>An ordered array of app id's to show as launchers</description>
     </key>


### PR DESCRIPTION
We added Files to the Plank in elementary/default-settings#271, so I think we should add it to our new dock too.