### PR TITLE
Fix memory leak with apps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+gee_dep = dependency('gee-0.8')
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
 glib_dep = dependency('glib-2.0')
@@ -27,6 +28,7 @@ wl_client_dep = dependency('wayland-client')
 subdir('protocol')
 
 dependencies = [
+    gee_dep,
     gio_dep,
     gio_unix_dep,
     glib_dep,

--- a/src/App.vala
+++ b/src/App.vala
@@ -83,10 +83,13 @@ public class Dock.App : Object {
 
         foreach (var action in app_info.list_actions ()) {
             var simple_action = new SimpleAction (APP_ACTION.printf (action), null);
-            simple_action.activate.connect (() => {
+            simple_action.activate.connect ((instance, variant) => {
                 var context = Gdk.Display.get_default ().get_app_launch_context ();
                 context.set_timestamp (Gdk.CURRENT_TIME);
-                //  launch (context, action);
+
+                // Don't use the local action to avoid memory leaks
+                var split = instance.name.split (".");
+                launch (context, split[1]);
             });
             action_group.add_action (simple_action);
         }

--- a/src/App.vala
+++ b/src/App.vala
@@ -24,9 +24,11 @@ public class Dock.App : Object {
     public SimpleActionGroup action_group { get; construct; }
     public Menu menu_model { get; construct; }
 
-    public GLib.List<AppWindow> windows { get; private owned set; } //Ordered by stacking order with topmost at 0
+    public Gee.List<AppWindow> windows { get; private owned set; } //Ordered by stacking order with topmost at 0
 
     private static Dock.SwitcherooControl switcheroo_control;
+
+    private SimpleAction pinned_action;
 
     public App (GLib.DesktopAppInfo app_info, bool pinned) {
         Object (app_info: app_info, pinned: pinned);
@@ -37,7 +39,7 @@ public class Dock.App : Object {
     }
 
     construct {
-        windows = new GLib.List<AppWindow> ();
+        windows = new Gee.LinkedList<AppWindow> ();
 
         action_group = new SimpleActionGroup ();
 
@@ -75,7 +77,7 @@ public class Dock.App : Object {
 
         var launcher_manager = LauncherManager.get_default ();
 
-        var pinned_action = new SimpleAction.stateful (PINNED_ACTION, null, new Variant.boolean (pinned));
+        pinned_action = new SimpleAction.stateful (PINNED_ACTION, null, new Variant.boolean (pinned));
         pinned_action.change_state.connect ((new_state) => pinned = (bool) new_state);
         action_group.add_action (pinned_action);
 
@@ -84,14 +86,14 @@ public class Dock.App : Object {
             simple_action.activate.connect (() => {
                 var context = Gdk.Display.get_default ().get_app_launch_context ();
                 context.set_timestamp (Gdk.CURRENT_TIME);
-                launch (context, action);
+                //  launch (context, action);
             });
             action_group.add_action (simple_action);
         }
 
         notify["pinned"].connect (() => {
             pinned_action.set_state (pinned);
-            launcher_manager.sync_pinned ();
+            LauncherManager.get_default ().sync_pinned ();
         });
     }
 
@@ -107,10 +109,10 @@ public class Dock.App : Object {
         try {
             if (action != null) {
                 app_info.launch_action (action, context);
-            } else if (windows.length () == 0) {
+            } else if (windows.size == 0) {
                 app_info.launch (null, context);
-            } else if (windows.length () == 1) {
-                LauncherManager.get_default ().desktop_integration.focus_window.begin (windows.first ().data.uid);
+            } else if (windows.size == 1) {
+                LauncherManager.get_default ().desktop_integration.focus_window.begin (windows.first ().uid);
             } else if (LauncherManager.get_default ().desktop_integration != null) {
                 LauncherManager.get_default ().desktop_integration.show_windows_for.begin (app_info.get_id ());
             }
@@ -150,21 +152,21 @@ public class Dock.App : Object {
         return false;
     }
 
-    public void update_windows (owned GLib.List<AppWindow>? new_windows) {
+    public void update_windows (Gee.List<AppWindow>? new_windows) {
         if (new_windows == null) {
-            windows = new GLib.List<AppWindow> ();
+            windows = new Gee.LinkedList<AppWindow> ();
         } else {
-            windows = (owned) new_windows;
+            windows = new_windows;
         }
     }
 
     public AppWindow? find_window (uint64 window_uid) {
-        unowned var found_win = windows.search<uint64?> (window_uid, (win, searched_uid) =>
-            win.uid == searched_uid ? 0 : win.uid > searched_uid ? 1 : -1
-        );
+        var found_win = windows.first_match ((win) => {
+            return win.uid == window_uid;
+        });
 
         if (found_win != null) {
-            return found_win.data;
+            return found_win;
         } else {
             return null;
         }
@@ -237,9 +239,9 @@ public class Dock.App : Object {
             Source.remove (timer_id);
         } else {
             yield LauncherManager.get_default ().sync_windows (); // Get the current stacking order
-            current_index = windows.length () > 1 && windows.first ().data.has_focus ? 1 : 0;
+            current_index = windows.size > 1 && windows.first ().has_focus ? 1 : 0;
             current_windows = {};
-            foreach (weak AppWindow window in windows) {
+            foreach (AppWindow window in windows) {
                 current_windows += window;
             }
         }

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -228,8 +228,6 @@ public class Dock.Launcher : Gtk.Box {
     }
 
     ~Launcher () {
-        warning ("Launcher destroyed");
-        warning ("App refs: %s", app.ref_count.to_string ());
         popover.unparent ();
         popover.dispose ();
     }

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -224,6 +224,8 @@ public class Dock.Launcher : Gtk.Box {
     }
 
     ~Launcher () {
+        warning ("Launcher destroyed");
+        warning ("App refs: %s", app.ref_count.to_string ());
         popover.unparent ();
         popover.dispose ();
     }

--- a/src/LauncherManager.vala
+++ b/src/LauncherManager.vala
@@ -233,10 +233,10 @@
             return;
         }
 
-        var app_window_list = new GLib.HashTable<App, GLib.List<AppWindow>> (direct_hash, direct_equal);
+        var app_window_list = new Gee.HashMap<App, Gee.List<AppWindow>> ();
         foreach (unowned var window in windows) {
             unowned var app_id = window.properties["app-id"].get_string ();
-            unowned App? app = id_to_app[app_id];
+            App? app = id_to_app[app_id];
             if (app == null) {
                 var app_info = new GLib.DesktopAppInfo (app_id);
                 if (app_info == null) {
@@ -253,19 +253,20 @@
 
             app_window.update_properties (window.properties);
 
-            unowned var window_list = app_window_list.get (app);
+            var window_list = app_window_list.get (app);
             if (window_list == null) {
-                var new_window_list = new GLib.List<AppWindow> ();
-                new_window_list.append ((owned) app_window);
-                app_window_list.insert (app, (owned) new_window_list);
+                var new_window_list = new Gee.LinkedList<AppWindow> ();
+                new_window_list.add (app_window);
+                app_window_list.set (app, new_window_list);
             } else {
-                window_list.append ((owned) app_window);
+                window_list.add (app_window);
             }
         }
 
         foreach (var app in id_to_app.get_values ()) {
-            var window_list = app_window_list.take (app);
-            app.update_windows ((owned) window_list);
+            Gee.List<AppWindow>? window_list = null;
+            app_window_list.unset (app, out window_list);
+            app.update_windows (window_list);
         }
 
         sync_pinned ();
@@ -300,7 +301,7 @@
         foreach (var launcher in launchers) {
             if (launcher.app.pinned) {
                 new_pinned_ids += launcher.app.app_info.get_id ();
-            } else if (!launcher.app.pinned && launcher.app.windows.is_empty ()) {
+            } else if (!launcher.app.pinned && launcher.app.windows.is_empty) {
                 launchers_to_remove += launcher;
             }
         }


### PR DESCRIPTION
Fixes a memory leak where apps weren't freed when they weren't needed anymore. 
We switch from glib.hashtable and glib.list s here to gee since working with the glib variants from vala code is hard when you want to not leak memory since it's designed with c in mind i guess (e.g. take will not unref the key and value). So why not use gee which was designed for vala.

This will only actually free apps with #249 since launchers hold a reference on apps.