### PR TITLE
Launcher: Keep animating until app was launched

### DIFF
--- a/data/dock.metainfo.xml.in
+++ b/data/dock.metainfo.xml.in
@@ -31,6 +31,7 @@
         <p>Hide badges, progressbars, and running indicators while dragging a launcher</p>
       </description>
       <issues>
+        <issue url="https://github.com/elementary/dock/issues/171">Icon animation or other feedback during slow launch</issue>
         <issue url="https://github.com/elementary/dock/issues/242">Clicking a launcher almost always registers a scroll</issue>
         <issue url="https://github.com/elementary/dock/issues/276">Changing Dock size left the dock with extra empty space</issue>
         <issue url="https://github.com/elementary/dock/issues/279">Dock using too much CPU/RAM</issue>

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -169,24 +169,22 @@ public class Dock.Launcher : Gtk.Box {
         ) {
             easing = EASE_OUT_BOUNCE
         };
+        bounce_down.done.connect (() => {
+            if (app.launching) {
+                Timeout.add_once (200, animate_launch);
+            }
+        });
 
         bounce_up = new Adw.TimedAnimation (
             this,
             0,
             0,
-            400,
+            200,
             bounce_animation_target
         ) {
             easing = EASE_IN_OUT_QUAD
         };
-        bounce_up.done.connect (() => {
-            if (app.launching || bounce_up.reverse) {
-                bounce_up.reverse = !bounce_up.reverse;
-                bounce_up.play ();
-            } else {
-                bounce_down.play ();
-            }
-        });
+        bounce_up.done.connect (bounce_down.play);
 
         var animation_target = new Adw.CallbackAnimationTarget ((val) => {
             launcher_manager.move (this, val, 0);

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -148,7 +148,7 @@ public class Dock.Launcher : Gtk.Box {
             }
         });
 
-        app.launching.connect (animate_launch);
+        app.launched.connect (animate_launch);
 
         var bounce_animation_target = new Adw.CallbackAnimationTarget ((val) => {
             var height = overlay.get_height ();
@@ -174,12 +174,19 @@ public class Dock.Launcher : Gtk.Box {
             this,
             0,
             0,
-            200,
+            400,
             bounce_animation_target
         ) {
             easing = EASE_IN_OUT_QUAD
         };
-        bounce_up.done.connect (bounce_down.play);
+        bounce_up.done.connect (() => {
+            if (app.launching || bounce_up.reverse) {
+                bounce_up.reverse = !bounce_up.reverse;
+                bounce_up.play ();
+            } else {
+                bounce_down.play ();
+            }
+        });
 
         var animation_target = new Adw.CallbackAnimationTarget ((val) => {
             launcher_manager.move (this, val, 0);


### PR DESCRIPTION
We keep animating until either a window appears or 10 seconds are over.

Fixes #171

I'm not to happy with the animation so someone from @elementary/ux should probably take a look. Currently it seems to slow when going over to the bounce down but keeping the 200 ms feel to fast when having to wait for an app to launch. We could also just do the normal bounce up and down and if the app hasn't launched by then we alternate its opacity?
Any ideas are welcome, also feel free to just push to this branch :)