### PR TITLE
App: Respect startup notify key for launching animation

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -11,7 +11,7 @@ public class Dock.App : Object {
     private const string APP_ACTION = "action.%s";
 
     public signal void launched () {
-        if (!running) {
+        if (!running && app_info.get_boolean ("StartupNotify")) {
             launching = true;
 
             Timeout.add_seconds (10, () => {


### PR DESCRIPTION
Fixes the multitasking view icon bouncing for the full 10 seconds.