### PR TITLE
MainWindow: Separate the container background from the window

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -18,7 +18,7 @@ dock {
         0 0 0 1px alpha(@borders, 0.4),
         0 1px 3px alpha(black, 0.10),
         0 3px 9px alpha(black, 0.15);
-    padding: 9px
+    padding: 9px;
 }
 
 launcher {

--- a/data/Application.css
+++ b/data/Application.css
@@ -1,7 +1,11 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2023 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2023-2024 elementary, Inc. (https://elementary.io)
  */
+
+dock-window {
+    margin: 16px 0 9px 0;
+}
 
 dock {
     background: alpha(@bg_color, 0.6);
@@ -14,8 +18,7 @@ dock {
         0 0 0 1px alpha(@borders, 0.4),
         0 1px 3px alpha(black, 0.10),
         0 3px 9px alpha(black, 0.15);
-    margin: 9px;
-    margin-top: 0;
+    padding: 9px
 }
 
 launcher {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,7 +1,13 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2022 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2022-2024 elementary, Inc. (https://elementary.io)
  */
+
+public class Dock.Container : Gtk.Box {
+    class construct {
+        set_css_name ("dock");
+    }
+}
 
 public class Dock.MainWindow : Gtk.ApplicationWindow {
     private static Settings settings = new Settings ("io.elementary.dock");
@@ -10,16 +16,28 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
     private Pantheon.Desktop.Panel? panel;
 
     class construct {
-        set_css_name ("dock");
+        set_css_name ("dock-window");
     }
 
     construct {
         var launcher_manager = LauncherManager.get_default ();
 
-        child = launcher_manager;
         overflow = VISIBLE;
         resizable = false;
         titlebar = new Gtk.Label ("") { visible = false };
+
+        var overlay = new Gtk.Overlay () {
+            child = new Dock.Container ()
+        };
+        overlay.add_overlay (launcher_manager);
+
+        var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
+        size_group.add_widget (overlay.child);
+        size_group.add_widget (launcher_manager);
+
+        child = overlay;
+
+        remove_css_class("background");
 
         // Fixes DnD reordering of launchers failing on a very small line between two launchers
         var drop_target_launcher = new Gtk.DropTarget (typeof (Launcher), MOVE);


### PR DESCRIPTION
Supersedes https://github.com/elementary/dock/pull/180
Fixes https://github.com/elementary/dock/issues/275