### PR TITLE
Add support for styles

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,7 +1,11 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2023 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2023-2024 elementary, Inc. (https://elementary.io)
  */
+
+dock-window {
+    margin: 16px 0 9px 0;
+}
 
 dock {
     background: alpha(@bg_color, 0.6);
@@ -14,8 +18,7 @@ dock {
         0 0 0 1px alpha(@borders, 0.4),
         0 1px 3px alpha(black, 0.10),
         0 3px 9px alpha(black, 0.15);
-    margin: 9px;
-    margin-top: 0;
+    padding: 9px
 }
 
 launcher {

--- a/data/Application.css
+++ b/data/Application.css
@@ -7,6 +7,10 @@ dock-window {
     margin: 16px 0 9px 0;
 }
 
+dock-window.traditional {
+    margin: 16px 0 0 0;
+}
+
 dock {
     background: alpha(@bg_color, 0.6);
     border-radius: 9px;
@@ -18,7 +22,26 @@ dock {
         0 0 0 1px alpha(@borders, 0.4),
         0 1px 3px alpha(black, 0.10),
         0 3px 9px alpha(black, 0.15);
-    padding: 9px
+    padding: 9px;
+}
+
+dock.traditional {
+    background: alpha(@bg_color, 0.7);
+    border-radius: 6px 6px 0 0;
+    box-shadow:
+        inset 0 -1px 0 0 alpha(@highlight_color, 0.2),
+        inset 0 1px 0 0 alpha(@highlight_color, 0.3),
+        inset 1px 0 0 0 alpha(@highlight_color, 0.07),
+        inset -1px 0 0 0 alpha(@highlight_color, 0.07),
+        0 0 0 1px alpha(@borders, 0.5),
+        0 1px 3px alpha(black, 0.12),
+        0 1px 2px alpha(black, 0.24);
+    margin-top: 32px;
+}
+
+dock.transparent {
+    background:none;
+    box-shadow: none;
 }
 
 launcher {

--- a/data/dock.gschema.xml
+++ b/data/dock.gschema.xml
@@ -8,10 +8,16 @@
     <value nick='always' value='4'/>
   </enum>
 
+  <enum id="Style">
+    <value nick='modern' value='0'/>
+    <value nick='traditional' value='1'/>
+    <value nick='transparent' value='2'/>
+  </enum>
+
   <schema path="/io/elementary/dock/" id="io.elementary.dock">
     <key enum="HideMode" name="autohide-mode">
       <default>'overlapping-focus-window'</default>
-      <summary> Autohide mode</summary>
+      <summary>Autohide mode</summary>
       <description>How autohide should be handled</description>
     </key>
 
@@ -19,6 +25,12 @@
       <default>48</default>
       <summary>Logical pixel size of app launcher icons</summary>
       <description>Logical pixel size of app launcher icons</description>
+    </key>
+
+    <key enum="Style" name="style">
+      <default>'modern'</default>
+      <summary>Appearance of the dock</summary>
+      <description>Appearance of the dock</description>
     </key>
 
     <key type="as" name="launchers">

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,7 +1,13 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2022 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2022-2024 elementary, Inc. (https://elementary.io)
  */
+
+public class Dock.Container : Gtk.Box {
+    class construct {
+        set_css_name ("dock");
+    }
+}
 
 public class Dock.MainWindow : Gtk.ApplicationWindow {
     private static Settings settings = new Settings ("io.elementary.dock");
@@ -10,16 +16,28 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
     private Pantheon.Desktop.Panel? panel;
 
     class construct {
-        set_css_name ("dock");
+        set_css_name ("dock-window");
     }
 
     construct {
         var launcher_manager = LauncherManager.get_default ();
 
-        child = launcher_manager;
         overflow = VISIBLE;
         resizable = false;
         titlebar = new Gtk.Label ("") { visible = false };
+
+        var overlay = new Gtk.Overlay () {
+            child = new Dock.Container ()
+        };
+        overlay.add_overlay (launcher_manager);
+
+        var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.BOTH);
+        size_group.add_widget (overlay.child);
+        size_group.add_widget (launcher_manager);
+
+        child = overlay;
+
+        remove_css_class("background");
 
         // Fixes DnD reordering of launchers failing on a very small line between two launchers
         var drop_target_launcher = new Gtk.DropTarget (typeof (Launcher), MOVE);


### PR DESCRIPTION
Closes https://github.com/elementary/dock/discussions/302
Closes https://github.com/orgs/elementary/discussions/589

Currently supports 3 styles:

# Modern
![image](https://github.com/user-attachments/assets/4959cf32-6732-403b-8cf1-f71aeb957de4)
![image](https://github.com/user-attachments/assets/cf85651f-4371-496d-9436-a0886c63b9d6)

# Traditional
![image](https://github.com/user-attachments/assets/5044b602-1f1d-40e7-b313-eaa5abe6d24e)
![image](https://github.com/user-attachments/assets/2ccbe6e5-e9e5-45c1-8a5e-26ccb7ba6def)

# Transparent
![image](https://github.com/user-attachments/assets/b21ee7a2-9807-4d2d-a461-ac22b8879647)
