### PR TITLE
meson: Specify minimum GLib version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,11 +13,12 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+glib_version = '2.74'
 gee_dep = dependency('gee-0.8')
-gio_dep = dependency('gio-2.0')
-gio_unix_dep = dependency('gio-unix-2.0')
-glib_dep = dependency('glib-2.0')
-gobject_dep = dependency('gobject-2.0')
+gio_dep = dependency('gio-2.0', version: '>=@0@'.format(glib_version))
+gio_unix_dep = dependency('gio-unix-2.0', version: '>=@0@'.format(glib_version))
+glib_dep = dependency('glib-2.0', version: '>=@0@'.format(glib_version))
+gobject_dep = dependency('gobject-2.0', version: '>=@0@'.format(glib_version))
 gtk_dep = dependency('gtk4')
 gtk_wayland_dep = dependency('gtk4-wayland')
 gtk_x11_dep = dependency('gtk4-x11')


### PR DESCRIPTION
We now require GLib 2.74 here.