### PR TITLE
Fix icons clipping when bouncing

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -15,7 +15,7 @@ dock {
         0 1px 3px alpha(black, 0.10),
         0 3px 9px alpha(black, 0.15);
     margin: 9px;
-    margin-top: 0;
+    margin-top: 32px; /* Keep enough room so that icons don't clip when bouncing */
 }
 
 launcher {


### PR DESCRIPTION
Fixes #275 without some issues introduced in #303 like a gap between maximized window and dock when set to never hide or offset context menus.

Requires elementary/gala#2108