### PR TITLE
Create fake app info for unknown windows

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -22,7 +22,7 @@ public class Dock.App : Object {
     }
 
     public bool pinned { get; construct set; }
-    public GLib.DesktopAppInfo app_info { get; construct; }
+    public Dock.AppInfo app_info { get; construct; }
 
     public bool count_visible { get; private set; default = false; }
     public int64 current_count { get; private set; default = 0; }
@@ -52,7 +52,7 @@ public class Dock.App : Object {
 
     private SimpleAction pinned_action;
 
-    public App (GLib.DesktopAppInfo app_info, bool pinned) {
+    public App (Dock.AppInfo app_info, bool pinned) {
         Object (app_info: app_info, pinned: pinned);
     }
 

--- a/src/AppInfo.vala
+++ b/src/AppInfo.vala
@@ -2,7 +2,7 @@
 
 public class Dock.AppInfo : GLib.Object {
     private const string[] NULL_ACTIONS = {};
-    private GLib.Icon FALLBACK_ICON = new GLib.ThemedIcon ("application-default-icon");
+    private GLib.Icon fallback_icon = new GLib.ThemedIcon ("application-default-icon");
 
     public GLib.DesktopAppInfo? desktop_app_info { get; construct; }
 
@@ -48,10 +48,10 @@ public class Dock.AppInfo : GLib.Object {
 
     public unowned GLib.Icon get_icon () {
         if (desktop_app_info == null) {
-            return FALLBACK_ICON;
+            return fallback_icon;
         }
 
-        return desktop_app_info.get_icon () ?? FALLBACK_ICON;
+        return desktop_app_info.get_icon () ?? fallback_icon;
     }
 
     public bool get_boolean (string key) {

--- a/src/AppInfo.vala
+++ b/src/AppInfo.vala
@@ -1,0 +1,104 @@
+// TODO: Copyright
+
+public class Dock.AppInfo : GLib.Object {
+    private const string[] NULL_ACTIONS = {};
+    private GLib.Icon FALLBACK_ICON = new GLib.ThemedIcon ("application-default-icon");
+
+    public GLib.DesktopAppInfo? desktop_app_info { get; construct; }
+
+    private string _fake_id = "Unknown";
+    public string? fake_id {
+        private get {
+            return _fake_id;
+        }
+        set {
+            _fake_id = value ?? "Unknown";
+        }
+    }
+
+    private string _fake_name = "Unknown";
+    public string? fake_name {
+        private get {
+            return _fake_name;
+        }
+        set {
+            _fake_name = value ?? "Unknown";
+        }
+    }
+
+    public AppInfo (GLib.DesktopAppInfo? desktop_app_info) {
+        Object (desktop_app_info: desktop_app_info);
+    }
+
+    public unowned string get_id () {
+        if (desktop_app_info == null) {
+            return fake_id;
+        }
+
+        return desktop_app_info.get_id ();
+    }
+
+    public unowned string get_display_name () {
+        if (desktop_app_info == null) {
+            return fake_name;
+        }
+
+        return desktop_app_info.get_display_name ();
+    }
+
+    public unowned GLib.Icon get_icon () {
+        if (desktop_app_info == null) {
+            return FALLBACK_ICON;
+        }
+
+        return desktop_app_info.get_icon () ?? FALLBACK_ICON;
+    }
+
+    public bool get_boolean (string key) {
+        if (desktop_app_info == null) {
+            return false;
+        }
+
+        return desktop_app_info.get_boolean (key);
+    }
+
+    public string get_string (string key) {
+        if (desktop_app_info == null) {
+            return "";
+        }
+
+        return desktop_app_info.get_string (key);
+    }
+
+    public unowned string[] list_actions () {
+        if (desktop_app_info == null) {
+            return NULL_ACTIONS;
+        }
+
+        return desktop_app_info.list_actions ();
+    }
+
+    public string get_action_name (string action_name) {
+        if (desktop_app_info == null) {
+            return "Something went wrong if you see this";
+        }
+
+        return desktop_app_info.get_action_name (action_name);
+    }
+
+    public void launch_action (string action_name, GLib.AppLaunchContext launch_context) {
+        if (desktop_app_info == null) {
+            return;
+        }
+
+        desktop_app_info.launch_action (action_name, launch_context);
+    }
+
+    public bool launch (GLib.List<GLib.File>? files, GLib.AppLaunchContext? context) throws GLib.Error {
+        if (desktop_app_info == null) {
+            return false;
+        }
+
+        return desktop_app_info.launch (files, context);
+    }
+}

--- a/src/Launcher.vala
+++ b/src/Launcher.vala
@@ -331,7 +331,9 @@ public class Dock.Launcher : Gtk.Box {
                 }
                 break;
             case Gdk.BUTTON_SECONDARY:
-                popover.popup ();
+                if (app.app_info.desktop_app_info != null) {
+                    popover.popup ();
+                }
                 break;
         }
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 sources = [
     'App.vala',
+    'AppInfo.vala',
     'Application.vala',
     'AppWindow.vala',
     'DesktopIntegration.vala',


### PR DESCRIPTION
Fixes https://github.com/elementary/dock/issues/310 (Basecamp app)

Some windows run in portable mode (for example AppImages) and they do not provide any .desktop files by default. Right now Dock doesn't even show these windows. This branch constructs fake app info for them and always shows them.

I couldn't find a way to trick GLib.DesktopAppInfo into using fake data, so I created a wrapper for it.