### PR TITLE
Fix warnings

### DIFF
--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  */
 
- public class Dock.BaseItem : Gtk.Box {
+public class Dock.BaseItem : Gtk.Box {
     protected static GLib.Settings dock_settings;
 
     static construct {
@@ -70,6 +70,8 @@
             })
         );
 
+        reveal.done.connect (set_revealed_finish);
+
         unowned var item_manager = ItemManager.get_default ();
         var animation_target = new Adw.CallbackAnimationTarget ((val) => {
             item_manager.move (this, val, 0);
@@ -112,11 +114,11 @@
 
         fade.play ();
         reveal.play ();
+    }
 
-        reveal.done.connect (() => {
-            overflow = VISIBLE;
-            revealed_done ();
-        });
+    private void set_revealed_finish () {
+        overflow = VISIBLE;
+        revealed_done ();
     }
 
     /**

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -14,7 +14,7 @@
     public Launcher? added_launcher { get; set; default = null; }
 
     private Adw.TimedAnimation resize_animation;
-    private List<Launcher> launchers; //Only used to keep track of launcher indices
+    private List<Launcher> launchers; // Only used to keep track of launcher indices
 
     static construct {
         settings = new Settings ("io.elementary.dock");
@@ -131,7 +131,7 @@
         }
     }
 
-    private void add_launcher_via_dnd (Launcher launcher, int index = -1) {
+    private void add_launcher_via_dnd (Launcher launcher, int index) {
         launcher.removed.connect (remove_item);
 
         launchers.insert (launcher, index);
@@ -139,7 +139,7 @@
         launcher.set_revealed (true);
     }
 
-    private void add_item (BaseItem item, int index = -1) {
+    private void add_item (BaseItem item) {
         item.removed.connect (remove_item);
 
         if (item is Launcher) {
@@ -170,7 +170,8 @@
     }
 
     private void remove_finish (BaseItem item) {
-        width_request = get_width (); //Temporarily set the width request to avoid flicker until the animation calls the callback for the first time
+        // Temporarily set the width request to avoid flicker until the animation calls the callback for the first time
+        width_request = get_width ();
 
         remove (item);
         reposition_items ();


### PR DESCRIPTION
Reducing diff of https://github.com/elementary/dock/pull/361

We call `set_revealed` twice -- when the icon created and when the icon is being removed. Because of this we remove the item twice which produces warning: `gtk_fixed_remove: assertion 'gtk_widget_get_parent (widget) == GTK_WIDGET (fixed)' failed`

Also I included minor comments/methods signature changes