### PR TITLE
Implement workspace reordering with drag and drop

### DIFF
--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -42,7 +42,7 @@ public class Dock.Launcher : BaseItem {
     private bool flagged_for_removal = false;
 
     public Launcher (App app) {
-        Object (app: app);
+        Object (app: app, group: Group.LAUNCHER);
     }
 
     class construct {

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -25,27 +25,6 @@ public class Dock.Launcher : BaseItem {
 
     public App app { get; construct; }
 
-    private bool _moving = false;
-    public bool moving {
-        get {
-            return _moving;
-        }
-
-        set {
-            _moving = value;
-
-            if (value) {
-                image.clear ();
-            } else {
-                image.gicon = app.app_info.get_icon ();
-            }
-
-            update_badge_revealer ();
-            update_progress_revealer ();
-            update_running_revealer ();
-        }
-    }
-
     private Gtk.Image image;
     private Gtk.Revealer progress_revealer;
     private Gtk.Revealer badge_revealer;
@@ -158,25 +137,6 @@ public class Dock.Launcher : BaseItem {
         };
         bounce_up.done.connect (bounce_down.play);
 
-        var drag_source = new Gtk.DragSource () {
-            actions = MOVE
-        };
-        add_controller (drag_source);
-        drag_source.prepare.connect (on_drag_prepare);
-        drag_source.drag_begin.connect (on_drag_begin);
-        drag_source.drag_cancel.connect (on_drag_cancel);
-        drag_source.drag_end.connect (() => {
-            if (!flagged_for_removal) {
-                moving = false;
-            }
-        });
-
-        var drop_target = new Gtk.DropTarget (typeof (Launcher), MOVE) {
-            preload = true
-        };
-        add_controller (drop_target);
-        drop_target.enter.connect (on_drop_enter);
-
         gesture_click.button = 0;
         gesture_click.released.connect (on_click_released);
 
@@ -212,10 +172,9 @@ public class Dock.Launcher : BaseItem {
         app.notify["progress-visible"].connect (update_progress_revealer);
         update_progress_revealer ();
 
-        app.bind_property ("running-on-active-workspace", running_revealer, "sensitive", SYNC_CREATE);
-
-        app.notify["running"].connect (update_running_revealer);
-        update_running_revealer ();
+        app.notify["running-on-active-workspace"].connect (update_active_state);
+        app.notify["running"].connect (update_active_state);
+        update_active_state ();
 
         var drop_target_file = new Gtk.DropTarget (typeof (File), COPY);
         add_controller (drop_target_file);
@@ -291,24 +250,7 @@ public class Dock.Launcher : BaseItem {
         bounce_up.play ();
     }
 
-    private Gdk.ContentProvider? on_drag_prepare (double x, double y) {
-        drag_offset_x = (int) x;
-        drag_offset_y = (int) y;
-
-        var val = Value (typeof (Launcher));
-        val.set_object (this);
-        return new Gdk.ContentProvider.for_value (val);
-    }
-
-    private void on_drag_begin (Gtk.DragSource drag_source, Gdk.Drag drag) {
-        var paintable = new Gtk.WidgetPaintable (image); //Maybe TODO How TF can I get a paintable from a gicon?!?!?
-        drag_source.set_icon (paintable.get_current_image (), drag_offset_x, drag_offset_y);
-        moving = true;
-
-        app.pinned = true; // Dragging communicates an implicit intention to pin the app
-    }
-
-    private bool on_drag_cancel (Gdk.Drag drag, Gdk.DragCancelReason reason) {
+    protected override bool drag_cancelled (Gdk.Drag drag, Gdk.DragCancelReason reason) {
         if (app.pinned && reason == NO_TARGET) {
             var popover = new PoofPopover ();
 
@@ -343,52 +285,8 @@ public class Dock.Launcher : BaseItem {
 
             return true;
         } else {
-            moving = false;
-            return false;
+            return base.drag_cancelled (drag, reason);
         }
-    }
-
-    private Gdk.DragAction on_drop_enter (Gtk.DropTarget drop_target, double x, double y) {
-        var val = drop_target.get_value ();
-        if (val != null) {
-            var obj = val.get_object ();
-
-            if (obj != null && obj is Launcher) {
-                calculate_dnd_move ((Launcher) obj, x, y);
-            }
-        }
-
-        return MOVE;
-    }
-
-    /**
-     * Calculates which side of #this source should be moved to.
-     * Depends on the direction from which the mouse cursor entered
-     * and whether source is already next to #this.
-     *
-     * @param source the launcher that's currently being reordered
-     * @param x pointer x position
-     * @param y pointer y position
-     */
-    private void calculate_dnd_move (Launcher source, double x, double y) {
-        var launcher_manager = ItemManager.get_default ();
-
-        int target_index = launcher_manager.get_index_for_launcher (this);
-        int source_index = launcher_manager.get_index_for_launcher (source);
-
-        if (source_index == target_index) {
-            return;
-        }
-
-        if (((x > get_width () / 2) && target_index + 1 == source_index) || // Cursor entered from the RIGHT and source IS our neighbouring launcher to the RIGHT
-            ((x < get_width () / 2) && target_index - 1 != source_index)    // Cursor entered from the LEFT and source is NOT our neighbouring launcher to the LEFT
-        ) {
-            // Move it to the left of us
-            target_index = target_index > 0 ? target_index-- : target_index;
-        }
-        // Else move it to the right of us
-
-        launcher_manager.move_launcher_after (source, target_index);
     }
 
     private void queue_dnd_cycle () {
@@ -406,12 +304,12 @@ public class Dock.Launcher : BaseItem {
     }
 
     private void update_badge_revealer () {
-        badge_revealer.reveal_child = !moving && app.count_visible
+        badge_revealer.reveal_child = app.count_visible
             && (notify_settings == null || !notify_settings.get_boolean ("do-not-disturb"));
     }
 
     private void update_progress_revealer () {
-        progress_revealer.reveal_child = !moving && app.progress_visible;
+        progress_revealer.reveal_child = app.progress_visible;
 
         // See comment above and https://github.com/elementary/dock/issues/279
         if (progress_revealer.reveal_child && progress_revealer.child == null) {
@@ -424,7 +322,11 @@ public class Dock.Launcher : BaseItem {
         }
     }
 
-    private void update_running_revealer () {
-        running_revealer.reveal_child = !moving && app.running;
+    private void update_active_state () {
+        if (!app.running) {
+            state = HIDDEN;
+        } else {
+            state = app.running_on_active_workspace ? State.ACTIVE : State.INACTIVE;
+        }
     }
 }

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -176,25 +176,6 @@ public class Dock.Launcher : BaseItem {
         app.notify["running"].connect (update_active_state);
         update_active_state ();
 
-        var drop_target_file = new Gtk.DropTarget (typeof (File), COPY);
-        add_controller (drop_target_file);
-
-        drop_target_file.enter.connect ((x, y) => {
-            var _launcher_manager = ItemManager.get_default ();
-            if (_launcher_manager.added_launcher != null) {
-                calculate_dnd_move (_launcher_manager.added_launcher, x, y);
-            }
-            return COPY;
-        });
-
-        drop_target_file.drop.connect (() => {
-            var _launcher_manager = ItemManager.get_default ();
-            if (_launcher_manager.added_launcher != null) {
-                _launcher_manager.added_launcher.moving = false;
-                _launcher_manager.added_launcher = null;
-            }
-        });
-
         var drop_controller_motion = new Gtk.DropControllerMotion ();
         add_controller (drop_controller_motion);
         drop_controller_motion.enter.connect (queue_dnd_cycle);

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -252,12 +252,8 @@ public class Dock.BaseItem : Gtk.Box {
 
     private Gdk.DragAction on_drop_enter (Gtk.DropTarget drop_target, double x, double y) {
         var val = drop_target.get_value ();
-        if (val != null) {
-            var obj = val.get_object ();
-
-            if (obj != null && obj is BaseItem && ((BaseItem) obj).group == group) {
-                calculate_dnd_move ((BaseItem) obj, x, y);
-            }
+        if (val != null && is_allowed_drop (val)) {
+            calculate_dnd_move ((BaseItem) val.get_object (), x, y);
         }
 
         return MOVE;
@@ -282,22 +278,19 @@ public class Dock.BaseItem : Gtk.Box {
             return;
         }
 
-        if (((x > get_width () / 2) && target_index + 1 == source_index) || // Cursor entered from the RIGHT and source IS our neighbouring launcher to the RIGHT
-            ((x < get_width () / 2) && target_index - 1 != source_index)    // Cursor entered from the LEFT and source is NOT our neighbouring launcher to the LEFT
-        ) {
-            // Move it to the left of us
-            target_index = target_index > 0 ? target_index - 1 : target_index;
-        }
-        // Else move it to the right of us
-
         launcher_manager.move_launcher_after (source, target_index);
     }
 
     private bool on_drop (Value val) {
-        if (val.type () == get_type ()) {
+        if (is_allowed_drop (val)) {
             ((BaseItem) val.get_object ()).moving = false;
             return true;
         }
         return false;
+    }
+
+    private bool is_allowed_drop (Value val) {
+        var obj = val.get_object ();
+        return obj != null && obj is BaseItem && ((BaseItem) obj).group == group;
     }
 }

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -27,7 +27,7 @@ public class Dock.BaseItem : Gtk.Box {
         get { return _moving; }
         set {
             _moving = value;
-            visible = !value;
+            overlay.visible = !value;
             running_revealer.reveal_child = !value && state != HIDDEN;
         }
     }
@@ -61,6 +61,11 @@ public class Dock.BaseItem : Gtk.Box {
 
         overlay = new Gtk.Overlay ();
 
+        // We need the bin because we need the animation to run even if the overlay is not visible
+        var bin = new Granite.Bin () {
+            child = overlay
+        };
+
         var running_indicator = new Gtk.Image.from_icon_name ("pager-checked-symbolic");
         running_indicator.add_css_class ("running-indicator");
 
@@ -72,7 +77,7 @@ public class Dock.BaseItem : Gtk.Box {
             valign = END
         };
 
-        append (overlay);
+        append (bin);
         append (running_revealer);
 
         icon_size = dock_settings.get_int ("icon-size");
@@ -91,10 +96,10 @@ public class Dock.BaseItem : Gtk.Box {
         };
 
         reveal = new Adw.TimedAnimation (
-            overlay, icon_size, 0,
+            bin, icon_size, 0,
             Granite.TRANSITION_DURATION_OPEN,
             new Adw.CallbackAnimationTarget ((val) => {
-                overlay.allocate (icon_size, icon_size, -1,
+                bin.allocate (icon_size, icon_size, -1,
                     new Gsk.Transform ().translate (Graphene.Point () { y = (float) val }
                 ));
             })

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -27,6 +27,15 @@ public class Dock.BaseItem : Gtk.Box {
         get { return _moving; }
         set {
             _moving = value;
+
+            if (value) {
+                bin.width_request = bin.get_width ();
+                bin.height_request = bin.get_height ();
+            } else {
+                bin.width_request = -1;
+                bin.height_request = -1;
+            }
+
             overlay.visible = !value;
             running_revealer.reveal_child = !value && state != HIDDEN;
         }
@@ -45,6 +54,7 @@ public class Dock.BaseItem : Gtk.Box {
     protected Gtk.Overlay overlay;
     protected Gtk.GestureClick gesture_click;
 
+    private Granite.Bin bin;
     private Gtk.Revealer running_revealer;
 
     private Adw.TimedAnimation fade;
@@ -62,7 +72,7 @@ public class Dock.BaseItem : Gtk.Box {
         overlay = new Gtk.Overlay ();
 
         // We need the bin because we need the animation to run even if the overlay is not visible
-        var bin = new Granite.Bin () {
+        bin = new Granite.Bin () {
             child = overlay
         };
 

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -19,6 +19,8 @@ public class Dock.BaseItem : Gtk.Box {
     public signal void removed ();
     public signal void revealed_done ();
 
+    public bool disallow_dnd { get; construct; default = false; }
+
     public int icon_size { get; set; }
     public double current_pos { get; set; }
 
@@ -135,6 +137,10 @@ public class Dock.BaseItem : Gtk.Box {
 
         gesture_click = new Gtk.GestureClick ();
         add_controller (gesture_click);
+
+        if (disallow_dnd) {
+            return;
+        }
 
         var drag_source = new Gtk.DragSource () {
             actions = MOVE

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -260,6 +260,10 @@
             return;
         }
 
+        if (target_index >= list.size) {
+            target_index = list.size - 1;
+        }
+
         int source_index = list.index_of (source);
 
         source.animate_move ((get_launcher_size () * target_index) + offset);
@@ -282,6 +286,8 @@
             return launchers.index_of ((Launcher) item);
         } else if (item is IconGroup) {
             return icon_groups.index_of ((IconGroup) item);
+        } else if (item == dynamic_workspace_item) { //treat dynamic workspace icon as last icon group
+            return icon_groups.size;
         }
 
         warning ("Tried to get index of neither launcher nor icon group");

--- a/src/WindowSystem/DesktopIntegration.vala
+++ b/src/WindowSystem/DesktopIntegration.vala
@@ -30,4 +30,5 @@ public interface Dock.DesktopIntegration : GLib.Object {
     public abstract async void activate_workspace (int index) throws GLib.DBusError, GLib.IOError;
     public abstract async int get_n_workspaces () throws GLib.DBusError, GLib.IOError;
     public abstract async int get_active_workspace () throws GLib.DBusError, GLib.IOError;
+    public abstract async void reorder_workspace (int index, int new_index) throws GLib.DBusError, GLib.IOError;
 }

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -9,7 +9,7 @@ public class Dock.DynamicWorkspaceIcon : BaseItem {
     }
 
     public DynamicWorkspaceIcon () {
-        Object ();
+        Object (disallow_dnd: true);
     }
 
     construct {

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -25,9 +25,9 @@ public class Dock.DynamicWorkspaceIcon : BaseItem {
 
         overlay.child = box;
 
-        WorkspaceSystem.get_default ().workspace_added.connect (update_running_indicator_visibility);
-        WorkspaceSystem.get_default ().workspace_removed.connect (update_running_indicator_visibility);
-        WindowSystem.get_default ().notify["active-workspace"].connect (update_running_indicator_visibility);
+        WorkspaceSystem.get_default ().workspace_added.connect (update_active_state);
+        WorkspaceSystem.get_default ().workspace_removed.connect (update_active_state);
+        WindowSystem.get_default ().notify["active-workspace"].connect (update_active_state);
 
         dock_settings.bind ("icon-size", box, "width-request", DEFAULT);
         dock_settings.bind ("icon-size", box, "height-request", DEFAULT);
@@ -49,10 +49,10 @@ public class Dock.DynamicWorkspaceIcon : BaseItem {
         gesture_click.released.connect (switch_to_new_workspace);
     }
 
-    private void update_running_indicator_visibility () {
+    private void update_active_state () {
         unowned var workspace_system = WorkspaceSystem.get_default ();
         unowned var window_system = WindowSystem.get_default ();
-        running_revealer.reveal_child = workspace_system.workspaces.size == window_system.active_workspace;
+        state = (workspace_system.workspaces.size == window_system.active_workspace) ? State.ACTIVE : State.HIDDEN;
     }
 
     private async void switch_to_new_workspace () {

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -9,7 +9,7 @@ public class Dock.DynamicWorkspaceIcon : BaseItem {
     }
 
     public DynamicWorkspaceIcon () {
-        Object (disallow_dnd: true);
+        Object (disallow_dnd: true, group: Group.WORKSPACE);
     }
 
     construct {

--- a/src/WorkspaceSystem/IconGroup.vala
+++ b/src/WorkspaceSystem/IconGroup.vala
@@ -18,7 +18,7 @@ public class Dock.IconGroup : BaseItem {
     }
 
     public IconGroup (Workspace workspace) {
-        Object (workspace: workspace);
+        Object (workspace: workspace, group: Group.WORKSPACE);
     }
 
     construct {

--- a/src/WorkspaceSystem/IconGroup.vala
+++ b/src/WorkspaceSystem/IconGroup.vala
@@ -34,7 +34,11 @@ public class Dock.IconGroup : BaseItem {
 
         overlay.child = box;
 
-        workspace.bind_property ("is-active-workspace", running_revealer, "reveal-child", SYNC_CREATE);
+        workspace.bind_property ("is-active-workspace", this, "state", SYNC_CREATE, (binding, from_value, ref to_value) => {
+            var new_val = from_value.get_boolean () ? State.ACTIVE : State.HIDDEN;
+            to_value.set_enum (new_val);
+            return true;
+        });
 
         update_icons ();
         workspace.notify["windows"].connect (update_icons);
@@ -47,6 +51,8 @@ public class Dock.IconGroup : BaseItem {
 
         gesture_click.button = Gdk.BUTTON_PRIMARY;
         gesture_click.released.connect (workspace.activate);
+
+        notify["moving"].connect (on_moving_changed);
     }
 
     private void update_icons () {
@@ -103,6 +109,12 @@ public class Dock.IconGroup : BaseItem {
         var pixel_size = get_pixel_size ();
 
         return (int) Math.round ((icon_size - pixel_size * MAX_IN_ROW) / 3);
+    }
+
+    private void on_moving_changed () {
+        if (!moving) {
+            workspace.reorder (ItemManager.get_default ().get_index_for_launcher (this));
+        }
     }
 
     /**

--- a/src/WorkspaceSystem/Workspace.vala
+++ b/src/WorkspaceSystem/Workspace.vala
@@ -4,6 +4,7 @@
  */
 
 public class Dock.Workspace : GLib.Object {
+    public signal void reordered (int new_index);
     public signal void removed ();
 
     public Gee.List<Window> windows { get; owned set; }
@@ -28,5 +29,10 @@ public class Dock.Workspace : GLib.Object {
         } else {
             WindowSystem.get_default ().desktop_integration.activate_workspace.begin (index);
         }
+    }
+
+    public void reorder (int new_index) {
+        reordered (new_index);
+        WindowSystem.get_default ().desktop_integration.reorder_workspace.begin (index, new_index);
     }
 }

--- a/src/WorkspaceSystem/WorkspaceSystem.vala
+++ b/src/WorkspaceSystem/WorkspaceSystem.vala
@@ -31,6 +31,7 @@ public class Dock.WorkspaceSystem : Object {
     private Workspace add_workspace () {
         var workspace = new Workspace ();
         workspaces.add (workspace);
+        workspace.reordered.connect (on_workspace_reordered);
         workspace_added (workspace);
         return workspace;
     }
@@ -104,5 +105,10 @@ public class Dock.WorkspaceSystem : Object {
             critical (e.message);
             return 0;
         }
+    }
+
+    private void on_workspace_reordered (Workspace workspace, int new_index) {
+        workspaces.remove (workspace);
+        workspaces.insert (new_index, workspace);
     }
 }


### PR DESCRIPTION
Fixes #381 
Requires elementary/gala#2320

A few things:
- when dragging and dropping the badge and progress are now attached to the icon which is IMO a bit cooler but can be easily changed back
- we use Gee.List because it's more suitable for the vala way of doing things. also use arraylist because we do a bunch of random access
- move all of the file dnd handling to the single file drop target in item manager. This prevents some races between multiple drop targets where the drop sometimes would be done on the one for the launchers and sometimes on the big one.