### PR TITLE
Make workspace switcher optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,10 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+if get_option('workspace-switcher')
+    vala_flags = ['--define', 'WORKSPACE_SWITCHER']
+endif
+
 glib_version = '2.74'
 gio_dep = dependency('gio-2.0', version: '>=@0@'.format(glib_version))
 gio_unix_dep = dependency('gio-unix-2.0', version: '>=@0@'.format(glib_version))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('workspace-switcher', type: 'boolean', value: false, description: 'Add workspace switcher to the dock')

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -26,11 +26,13 @@
         launchers = new GLib.GenericArray<Launcher> ();
         icon_groups = new GLib.GenericArray<IconGroup> ();
 
+#if WORKSPACE_SWITCHER
         // Idle is used here to because DynamicWorkspaceIcon depends on ItemManager
         Idle.add_once (() => {
             dynamic_workspace_item = new DynamicWorkspaceIcon ();
             add_item (dynamic_workspace_item);
         });
+#endif
 
         overflow = VISIBLE;
 
@@ -153,13 +155,17 @@
             add_item (launcher);
         });
 
+#if WORKSPACE_SWITCHER
         WorkspaceSystem.get_default ().workspace_added.connect ((workspace) => {
             add_item (new IconGroup (workspace));
         });
+#endif
 
         map.connect (() => {
             AppSystem.get_default ().load.begin ();
+#if WORKSPACE_SWITCHER
             WorkspaceSystem.get_default ().load.begin ();
+#endif
         });
     }
 
@@ -173,7 +179,9 @@
             position_item (icon_group, ref index);
         }
 
+#if WORKSPACE_SWITCHER
         position_item (dynamic_workspace_item, ref index);
+#endif
     }
 
     private void position_item (BaseItem item, ref int index) {


### PR DESCRIPTION
So we can continue to make bugfix etc releases while we continue to work on the workspace switcher

After merging we can change the LP recipe to use this packaging branch in daily: https://github.com/elementary/dock/tree/deb-packaging-daily