### PR TITLE
Revert "GSchema: remove multitasking from defaults"

### DIFF
--- a/data/dock.gschema.xml
+++ b/data/dock.gschema.xml
@@ -22,7 +22,7 @@
     </key>
 
     <key type="as" name="launchers">
-      <default>['io.elementary.files.desktop', 'org.gnome.Epiphany.desktop', 'io.elementary.mail.desktop', 'io.elementary.tasks.desktop', 'io.elementary.calendar.desktop', 'io.elementary.music.desktop', 'io.elementary.videos.desktop', 'io.elementary.photos.desktop', 'io.elementary.settings.desktop', 'io.elementary.appcenter.desktop', 'io.elementary.installer.desktop']</default>
+      <default>['gala-multitaskingview.desktop', 'io.elementary.files.desktop', 'org.gnome.Epiphany.desktop', 'io.elementary.mail.desktop', 'io.elementary.tasks.desktop', 'io.elementary.calendar.desktop', 'io.elementary.music.desktop', 'io.elementary.videos.desktop', 'io.elementary.photos.desktop', 'io.elementary.settings.desktop', 'io.elementary.appcenter.desktop', 'io.elementary.installer.desktop']</default>
       <summary>An ordered array of app id's to show as launchers</summary>
       <description>An ordered array of app id's to show as launchers</description>
     </key>


### PR DESCRIPTION
Reverts elementary/dock#386

Revert this for now since we're building workspace switcher optionally. We can revert reverting when workspace switcher builds by default :)