### PR TITLE
Create fake app info for unknown windows

### DIFF
--- a/src/AppSystem/App.vala
+++ b/src/AppSystem/App.vala
@@ -24,7 +24,7 @@ public class Dock.App : Object {
     public signal void removed ();
 
     public bool pinned { get; construct set; }
-    public GLib.DesktopAppInfo app_info { get; construct; }
+    public Dock.AppInfo app_info { get; construct; }
 
     public bool count_visible { get; private set; default = false; }
     public int64 current_count { get; private set; default = 0; }
@@ -54,7 +54,7 @@ public class Dock.App : Object {
 
     private SimpleAction pinned_action;
 
-    public App (GLib.DesktopAppInfo app_info, bool pinned) {
+    public App (Dock.AppInfo app_info, bool pinned) {
         Object (app_info: app_info, pinned: pinned);
     }
 

--- a/src/AppSystem/AppInfo.vala
+++ b/src/AppSystem/AppInfo.vala
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ */
+
+public class Dock.AppInfo : GLib.Object {
+    private const string[] NULL_ACTIONS = {};
+    private GLib.Icon fallback_icon = new GLib.ThemedIcon ("application-default-icon");
+
+    public GLib.DesktopAppInfo? desktop_app_info { get; construct; }
+
+    private string _fake_id = "Unknown";
+    public string? fake_id {
+        private get {
+            return _fake_id;
+        }
+        set {
+            _fake_id = value ?? "Unknown";
+        }
+    }
+
+    private string _fake_name = "Unknown";
+    public string? fake_name {
+        private get {
+            return _fake_name;
+        }
+        set {
+            _fake_name = value ?? "Unknown";
+        }
+    }
+
+    public AppInfo (GLib.DesktopAppInfo? desktop_app_info) {
+        Object (desktop_app_info: desktop_app_info);
+    }
+
+    public unowned string get_id () {
+        if (desktop_app_info == null) {
+            return fake_id;
+        }
+
+        return desktop_app_info.get_id ();
+    }
+
+    public unowned string get_display_name () {
+        if (desktop_app_info == null) {
+            return fake_name;
+        }
+
+        return desktop_app_info.get_display_name ();
+    }
+
+    public unowned GLib.Icon get_icon () {
+        if (desktop_app_info == null) {
+            return fallback_icon;
+        }
+
+        return desktop_app_info.get_icon () ?? fallback_icon;
+    }
+
+    public bool get_boolean (string key) {
+        if (desktop_app_info == null) {
+            return false;
+        }
+
+        return desktop_app_info.get_boolean (key);
+    }
+
+    public string get_string (string key) {
+        if (desktop_app_info == null) {
+            return "";
+        }
+
+        return desktop_app_info.get_string (key);
+    }
+
+    public unowned string[] list_actions () {
+        if (desktop_app_info == null) {
+            return NULL_ACTIONS;
+        }
+
+        return desktop_app_info.list_actions ();
+    }
+
+    public string get_action_name (string action_name) {
+        if (desktop_app_info == null) {
+            return "Something went wrong if you see this";
+        }
+
+        return desktop_app_info.get_action_name (action_name);
+    }
+
+    public void launch_action (string action_name, GLib.AppLaunchContext launch_context) {
+        if (desktop_app_info == null) {
+            return;
+        }
+
+        desktop_app_info.launch_action (action_name, launch_context);
+    }
+
+    public bool launch (GLib.List<GLib.File>? files, GLib.AppLaunchContext? context) throws GLib.Error {
+        if (desktop_app_info == null) {
+            return false;
+        }
+
+        return desktop_app_info.launch (files, context);
+    }
+}

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -232,7 +232,9 @@ public class Dock.Launcher : BaseItem {
                 }
                 break;
             case Gdk.BUTTON_SECONDARY:
-                popover.popup ();
+                if (app.app_info.desktop_app_info != null) {
+                    popover.popup ();
+                }
                 break;
         }
     }

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -77,7 +77,7 @@
             }
 
             var file = (File) drop_target_file.get_value ().get_object ();
-            var app_info = new DesktopAppInfo.from_filename (file.get_path ());
+            var app_info = new GLib.DesktopAppInfo.from_filename (file.get_path ());
 
             if (app_info == null) {
                 return;

--- a/src/WindowSystem/Window.vala
+++ b/src/WindowSystem/Window.vala
@@ -6,8 +6,8 @@
 
 public class Dock.Window : GLib.Object {
     public uint64 uid { get; construct set; }
-
     public string app_id { get; private set; default = ""; }
+    public string? title { get; private set; default = null; }
     public bool has_focus { get; private set; default = false; }
     public int workspace_index { get; private set; default = 0; }
     public int64 time_appeared_on_workspace { get; private set; default = 0; }
@@ -22,6 +22,10 @@ public class Dock.Window : GLib.Object {
     public void update_properties (GLib.HashTable<string, Variant> properties) {
         if ("app-id" in properties) {
             app_id = properties["app-id"].get_string ();
+        }
+
+        if ("title" in properties) {
+            title = properties["title"].get_string ();
         }
 
         if ("has-focus" in properties) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ sources = [
     'ItemManager.vala',
     'MainWindow.vala',
     'AppSystem' / 'App.vala',
+    'AppSystem' / 'AppInfo.vala',
     'AppSystem' / 'AppSystem.vala',
     'AppSystem' / 'Launcher.vala',
     'AppSystem' / 'PoofPopover.vala',


### PR DESCRIPTION
Fixes https://github.com/elementary/dock/issues/310 (Basecamp app)

Some windows run in portable mode (for example AppImages) and they do not provide any .desktop files by default. Right now Dock doesn't even show these windows. This branch constructs fake app info for them and always shows them.

I couldn't find a way to trick GLib.DesktopAppInfo into using fake data, so I created a wrapper for it.