### PR TITLE
Use built-in styles, improve screenreader

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -60,6 +60,7 @@ launcher progressbar progress {
     min-width: 0;
 }
 
+backgrounditem,
 icongroup {
     padding: 6px;
     padding-bottom: 0;
@@ -88,6 +89,19 @@ icongroup .add-image {
     -gtk-icon-shadow: 0 1px 0 alpha(@highlight_color, 0.2);
 }
 
+backgrounditem header {
+    padding: 0.5em 1em;
+}
+
+/*Workaround for bug with headers in popover*/
+backgrounditem header .heading {
+    margin: 0;
+}
+
+backgrounditem .close-button {
+    padding: 0.125em;
+}
+
 .reduce-transparency .add-image {
     color: @selected_fg_color;
 }
@@ -99,9 +113,4 @@ icongroup .add-image {
 
 .running-indicator:disabled {
     color: @text_color;
-}
-
-backgrounditem {
-    padding: 6px;
-    padding-bottom: 0;
 }

--- a/src/AppSystem/Background/BackgroundAppRow.vala
+++ b/src/AppSystem/Background/BackgroundAppRow.vala
@@ -27,13 +27,15 @@ public class Dock.BackgroundAppRow : Gtk.ListBoxRow {
             hexpand = true
         };
         message.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+        message.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         var button = new Gtk.Button.from_icon_name ("window-close-symbolic") {
             valign = CENTER,
-            halign = CENTER,
-            tooltip_text = _("End this App"),
+            tooltip_text = _("Quit"),
         };
-        button.add_css_class ("circular");
+        button.add_css_class ("close-button");
+        button.add_css_class (Granite.STYLE_CLASS_CIRCULAR);
+        button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         var spinner = new Gtk.Spinner () {
             spinning = true
@@ -47,24 +49,19 @@ public class Dock.BackgroundAppRow : Gtk.ListBoxRow {
 
         var grid = new Gtk.Grid () {
             column_spacing = 9,
-            row_spacing = 3,
-            margin_top = 3,
-            margin_bottom = 3,
-            margin_start = 9,
-            margin_end = 9
+            row_spacing = 3
         };
         grid.attach (icon, 0, 0, 1, 2);
 
         if (app.message != null) {
-            grid.attach (name, 1, 0, 1, 1);
-            grid.attach (message, 1, 1, 1, 1);
+            grid.attach (name, 1, 0);
+            grid.attach (message, 1, 1);
         } else {
             grid.attach (name, 1, 0, 1, 2);
         }
 
         grid.attach (button_stack, 2, 0, 1, 2);
 
-        width_request = 200;
         child = grid;
 
         button.clicked.connect (() => {

--- a/src/AppSystem/Background/BackgroundItem.vala
+++ b/src/AppSystem/Background/BackgroundItem.vala
@@ -17,41 +17,21 @@ public class Dock.BackgroundItem : BaseItem {
     construct {
         monitor = new BackgroundMonitor ();
 
-        var header_icon = new Gtk.Image.from_icon_name ("background") {
-            icon_size = LARGE
-        };
-
-        var header_label = new Gtk.Label (_("Background Apps")) {
-            xalign = 0,
-        };
-
-        var description_label = new Gtk.Label (_("These apps are running without a visible window.")) {
-            xalign = 0,
-        };
-        description_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
-
-        var header_grid = new Gtk.Grid () {
-            margin_start = 9,
-            margin_end = 9,
-            column_spacing = 9,
-        };
-        header_grid.attach (header_icon, 0, 0, 1, 2);
-        header_grid.attach (header_label, 1, 0, 1, 1);
-        header_grid.attach (description_label, 1, 1, 1, 1);
-
         var placeholder = new Granite.Placeholder (_("No apps running in the background"));
 
         var list_box = new Gtk.ListBox () {
-            selection_mode = NONE,
+            selection_mode = BROWSE
         };
         list_box.bind_model (monitor.background_apps, create_widget_func);
         list_box.set_placeholder (placeholder);
 
-        var box = new Gtk.Box (VERTICAL, 6) {
-            margin_top = 12,
-            margin_bottom = 6,
+        var header_label = new Granite.HeaderLabel (_("Background Apps")) {
+            mnemonic_widget = list_box,
+            secondary_text = _("Apps running without a visible window.")
         };
-        box.append (header_grid);
+
+        var box = new Gtk.Box (VERTICAL, 0);
+        box.append (header_label);
         box.append (new Gtk.Separator (HORIZONTAL));
         box.append (list_box);
 
@@ -59,6 +39,7 @@ public class Dock.BackgroundItem : BaseItem {
             position = TOP,
             child = box
         };
+        popover.add_css_class (Granite.STYLE_CLASS_MENU);
         popover.set_parent (this);
 
         var image = new Gtk.Image.from_icon_name ("background");


### PR DESCRIPTION
Some proposed changes to the popover

* Use `MENU` style. Saves us a bunch of manually setting of margins, padding etc
* Remove the icon from the header and use Granite.HeaderLabel. More clearly visually separates the header from the list of apps stylistically
* Make the secondary text of the header a little more concise
* Set the header as mnemonic widget for the list so the screenreader associates it and reads it correctly
* Make secondary text for app rows small text to give more visual hierarchy and make more room for long labels
* Change tooltip for button to "Quit" to be more concise
* Make buttons destructive styled and slightly smaller

## AFTER

![Screenshot from 2025-07-07 14 43 53](https://github.com/user-attachments/assets/f1c9bee3-8f23-4e34-b527-e7825ecfdd5d)

## BEFORE

![Screenshot from 2025-07-07 14 49 29](https://github.com/user-attachments/assets/9e9690f2-cdbb-43e4-b7f3-3d34e35b320f)
