### PR TITLE
Use shadow width instead of custom size

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -107,7 +107,7 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
             unowned var surface = get_surface ();
             var item_manager_width = ItemManager.get_default ().get_width ();
             var shadow_size = (surface.width - item_manager_width) / 2;
-            var top_margin = TOP_MARGIN + shadow_size;
+            var top_margin = TOP_MARGIN + shadow_size - 1;
             size.set_shadow_width (shadow_size, shadow_size, top_margin, shadow_size);
         });
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -102,6 +102,16 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
 
     private static Wl.RegistryListener registry_listener;
     private void init_panel () {
+        ((Gdk.Toplevel) get_surface ()).compute_size.connect ((size) => {
+            // manually set shadow width since the additional margin we add to avoid icons clipping when
+            // bouncing isn't added by default and instead counts to the frame
+            unowned var surface = get_surface ();
+            var item_manager_width = ItemManager.get_default ().get_width ();
+            var shadow_size = (surface.width - item_manager_width) / 2;
+            var top_margin = TOP_MARGIN + shadow_size;
+            size.set_shadow_width (shadow_size, shadow_size, top_margin, shadow_size);
+        });
+
         get_surface ().layout.connect_after (() => {
             // manually set input region since container's shadow are is the content of the window
             // and it still gets window events
@@ -115,19 +125,6 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
                 item_manager_width,
                 surface.height - top_margin
             }));
-
-            var new_height = main_box.get_height ();
-            if (new_height == height) {
-                return;
-            }
-
-            height = new_height;
-
-            if (panel != null) {
-                panel.set_size (-1, height);
-            } else {
-                update_panel_x11 ();
-            }
         });
 
         registry_listener.global = registry_handle_global;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -26,7 +26,6 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
     private Pantheon.Desktop.Panel? panel;
 
     private Gtk.Box main_box;
-    private int height = 0;
 
     class construct {
         set_css_name ("dock-window");
@@ -154,7 +153,7 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
 
             var prop = xdisplay.intern_atom ("_MUTTER_HINTS", false);
 
-            var value = "anchor=8:hide-mode=%d:size=-1,%d:restore-previous-region=1".printf (settings.get_enum ("autohide-mode"), height);
+            var value = "anchor=8:hide-mode=%d:restore-previous-region=1".printf (settings.get_enum ("autohide-mode"));
 
             xdisplay.change_property (window, prop, X.XA_STRING, 8, 0, (uchar[]) value, value.length);
         }


### PR DESCRIPTION
What we currently achieve by setting a custom size via our wayland protocol is actually supported by default in wayland via the shadow width which maps to frame rect and buffer rect in mutter. I only found out about shadow width recently so I always thought frame rect and buffer rect are somewhat broken or rather use something else :grimacing: 

Setting the shadow width ourselves allows us to remove the custom size method from our wayland protocol and the custom rect handling which has caused a few issues in the past because of wrong coordinate conversion on different scaling factors and methods. (See elementary/wingpanel#568, elementary/wingpanel#594, elementary/gala#2139, etc.)

Fixes #351 (On X that requires a dock restart for some reason? I think that's due to a bug in gala but I will investigate in a follow up since ig it's at least better than main)