### PR TITLE
Styles: Fix "Active on Other Workspace" indicator color

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -116,5 +116,5 @@ backgrounditem .close-button {
 }
 
 .running-indicator:disabled {
-    color: @text_color;
+    color: @fg_color;
 }


### PR DESCRIPTION
In light mode, particularly when transparency was reduced or a window with a light background was behind the dock, the indicator would disappear.

## Before

<img width="1449" height="72" alt="image" src="https://github.com/user-attachments/assets/9e64906d-266d-465b-8ab4-d22157f756ae" />

<img width="1448" height="77" alt="image" src="https://github.com/user-attachments/assets/0aa55b7a-4d87-42bd-a609-f53eb73fc2da" />

## After

<img width="1451" height="76" alt="image" src="https://github.com/user-attachments/assets/f8c61014-97c8-4e89-9577-54705374cc89" />

<img width="1450" height="76" alt="image" src="https://github.com/user-attachments/assets/d48c941f-6ead-46e8-95f6-529ab1fcbb18" />

