### PR TITLE
MainWindow: only request multitasking view if workspace switcher enabled

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -99,7 +99,9 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
                 panel = desktop_shell.get_panel (wl_surface);
                 panel.set_anchor (BOTTOM);
                 panel.set_hide_mode (settings.get_enum ("autohide-mode"));
+#if WORKSPACE_SWITCHER
                 panel.request_visible_in_multitasking_view ();
+#endif
             }
         }
     }


### PR DESCRIPTION
Don't request multitasking view visibility if we're not showing the workspace switcher.

Unblocks releasing to stable. Dock just crashes without this