### PR TITLE
Default to building workspace switcher

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('workspace-switcher', type: 'boolean', value: false, description: 'Add workspace switcher to the dock')
+option('workspace-switcher', type: 'boolean', value: true, description: 'Add workspace switcher to the dock')


### PR DESCRIPTION
Now that we have Gala 8.3.0 (and we depend on it), default to building with the workspace switcher