### PR TITLE
BackgroundItem: use symbolic icons

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -103,6 +103,10 @@ icongroup .add-image {
     -gtk-icon-shadow: 0 1px 0 alpha(@highlight_color, 0.2);
 }
 
+icongroup.background-apps image {
+    -gtk-icon-style: symbolic;
+}
+
 backgrounditem header {
     padding: 0.5em 1em;
 }

--- a/src/AppSystem/Background/BackgroundItem.vala
+++ b/src/AppSystem/Background/BackgroundItem.vala
@@ -47,6 +47,8 @@ public class Dock.BackgroundItem : BaseIconGroup {
         popover.add_css_class (Granite.STYLE_CLASS_MENU);
         popover.set_parent (this);
 
+        add_css_class ("background-apps");
+
         monitor.background_apps.items_changed.connect ((pos, n_removed, n_added) => {
             if (monitor.background_apps.get_n_items () == 0) {
                 popover.popdown ();


### PR DESCRIPTION
Related to #447 

Theoretically make background apps use symbolic icons.

Probably needs a more specific selector since I think this will also change the menu items