### PR TITLE
Give the new ws icon the same focus style as the icon groups.

### DIFF
--- a/src/BaseIconGroup.vala
+++ b/src/BaseIconGroup.vala
@@ -3,15 +3,11 @@
  * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  */
 
-public abstract class Dock.BaseIconGroup : BaseItem {
+public abstract class Dock.BaseIconGroup : ContainerItem {
     private const int MAX_IN_ROW = 2;
     private const int MAX_N_CHILDREN = MAX_IN_ROW * MAX_IN_ROW;
 
     public ListModel icons { get; construct; }
-
-    class construct {
-        set_css_name ("icongroup");
-    }
 
     construct {
         var slice = new Gtk.SliceListModel (icons, 0, MAX_N_CHILDREN);
@@ -25,22 +21,7 @@ public abstract class Dock.BaseIconGroup : BaseItem {
         };
         flow_box.bind_model (slice, create_flow_box_child);
 
-        var bin = new Granite.Bin () {
-            child = flow_box
-        };
-        bin.add_css_class ("icon-group-bin");
-        bind_property ("icon-size", bin, "width-request", SYNC_CREATE);
-        bind_property ("icon-size", bin, "height-request", SYNC_CREATE);
-
-        overlay.child = bin;
-
-        notify["state"].connect (() => {
-            if ((state != HIDDEN) && !moving) {
-                add_css_class ("running");
-            } else if (has_css_class ("running")) {
-                remove_css_class ("running");
-            }
-        });
+        child = flow_box;
     }
 
     private Gtk.Widget create_flow_box_child (Object? item) {

--- a/src/ContainerItem.vala
+++ b/src/ContainerItem.vala
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ */
+
+public abstract class Dock.ContainerItem : BaseItem {
+    class construct {
+        set_css_name ("icongroup");
+    }
+
+    public Gtk.Widget child { get { return container.child; } set { container.child = value; } }
+
+    private Granite.Bin container;
+
+    construct {
+        container = new Granite.Bin ();
+        container.add_css_class ("icon-group-bin");
+        bind_property ("icon-size", container, "width-request", SYNC_CREATE);
+        bind_property ("icon-size", container, "height-request", SYNC_CREATE);
+
+        overlay.child = container;
+
+        notify["state"].connect (() => {
+            if ((state != HIDDEN) && !moving) {
+                add_css_class ("running");
+            } else if (has_css_class ("running")) {
+                remove_css_class ("running");
+            }
+        });
+    }
+}

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -3,11 +3,7 @@
  * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  */
 
-public class Dock.DynamicWorkspaceIcon : BaseItem {
-    class construct {
-        set_css_name ("icongroup");
-    }
-
+public class Dock.DynamicWorkspaceIcon : ContainerItem {
     public DynamicWorkspaceIcon () {
         Object (disallow_dnd: true, group: Group.WORKSPACE);
     }
@@ -19,20 +15,11 @@ public class Dock.DynamicWorkspaceIcon : BaseItem {
         };
         add_image.add_css_class ("add-image");
 
-        // Granite.Bin is used here to keep css nodes consistent with IconGroup
-        var bin = new Granite.Bin () {
-            child = add_image
-        };
-        bin.add_css_class ("icon-group-bin");
-
-        overlay.child = bin;
+        child = add_image;
 
         WorkspaceSystem.get_default ().workspace_added.connect (update_active_state);
         WorkspaceSystem.get_default ().workspace_removed.connect (update_active_state);
         WindowSystem.get_default ().notify["active-workspace"].connect (update_active_state);
-
-        dock_settings.bind ("icon-size", bin, "width-request", DEFAULT);
-        dock_settings.bind ("icon-size", bin, "height-request", DEFAULT);
 
         dock_settings.bind_with_mapping (
             "icon-size", add_image, "pixel_size", DEFAULT | GET,

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ sources = [
     'BaseIconGroup.vala',
     'BaseItem.vala',
     'BottomMargin.vala',
+    'ContainerItem.vala',
     'ItemManager.vala',
     'MainWindow.vala',
     'RenderNodeWalker.vala',


### PR DESCRIPTION
Introduce a container item (I couldn't come up with a better name) base class from that baseicongroup and dynamic workspace inherit. This drys some code and makes sure the dynamic workspace icon receives the same focus style when active as the other workspaces.