### PR TITLE
BaseIconGroup: make flowbox child unfocusable

### DIFF
--- a/src/BaseIconGroup.vala
+++ b/src/BaseIconGroup.vala
@@ -41,6 +41,7 @@ public abstract class Dock.BaseIconGroup : ContainerItem {
 
         return new Gtk.FlowBoxChild () {
             child = image,
+            can_focus = false,
             can_target = false
         };
     }


### PR DESCRIPTION
Fixes a small visual bug where the first flowbox child in the first icon group has a keyboard focus indicator:

## BEFORE
<img width="84" height="96" alt="Screenshot from 2025-11-25 09 29 51@2x" src="https://github.com/user-attachments/assets/98581c77-489e-458e-b5df-116fc17d7806" />

## AFTER
<img width="89" height="102" alt="Screenshot from 2025-11-25 09 30 14@2x" src="https://github.com/user-attachments/assets/48a06659-a0b2-4d28-b0ab-5d5d606548ed" />
