### PR TITLE
Make pinned action a property action

### DIFF
--- a/src/AppSystem/App.vala
+++ b/src/AppSystem/App.vala
@@ -6,7 +6,6 @@
 public class Dock.App : Object {
     public const string ACTION_GROUP_PREFIX = "app-actions";
     private const string ACTION_PREFIX = ACTION_GROUP_PREFIX + ".";
-    private const string PINNED_ACTION = "pinned";
     private const string SWITCHEROO_ACTION = "switcheroo";
     private const string APP_ACTION = "action.%s";
 
@@ -46,14 +45,12 @@ public class Dock.App : Object {
     }
     public bool launching { get; private set; default = false; }
 
-    public SimpleActionGroup action_group { get; construct; }
-    public Menu menu_model { get; construct; }
+    public SimpleActionGroup app_action_group { get; construct; }
+    public Menu app_action_menu { get; construct; }
 
     public GLib.GenericArray<Window> windows { get; private owned set; } // Ordered by stacking order with topmost at 0
 
     private static Dock.SwitcherooControl switcheroo_control;
-
-    private SimpleAction pinned_action;
 
     public App (GLib.DesktopAppInfo app_info, bool pinned) {
         Object (app_info: app_info, pinned: pinned);
@@ -66,11 +63,11 @@ public class Dock.App : Object {
     construct {
         windows = new GLib.GenericArray<Window> ();
 
-        action_group = new SimpleActionGroup ();
+        app_action_group = new SimpleActionGroup ();
 
-        var action_section = new Menu ();
+        app_action_menu = new Menu ();
         foreach (var action in app_info.list_actions ()) {
-            action_section.append (app_info.get_action_name (action), ACTION_PREFIX + APP_ACTION.printf (action));
+            app_action_menu.append (app_info.get_action_name (action), ACTION_PREFIX + APP_ACTION.printf (action));
         }
 
         if (switcheroo_control != null && switcheroo_control.has_dual_gpu) {
@@ -83,26 +80,13 @@ public class Dock.App : Object {
                 launch (context, null, false);
             });
 
-            action_group.add_action (switcheroo_action);
+            app_action_group.add_action (switcheroo_action);
 
-            action_section.append (
+            app_action_menu.append (
                 _("Open with %s Graphics").printf (switcheroo_control.get_gpu_name (!prefers_nondefault_gpu)),
                 ACTION_PREFIX + SWITCHEROO_ACTION
             );
         }
-
-        var pinned_section = new Menu ();
-        pinned_section.append (_("Keep in Dock"), ACTION_PREFIX + PINNED_ACTION);
-
-        menu_model = new Menu ();
-        if (action_section.get_n_items () > 0) {
-            menu_model.append_section (null, action_section);
-        }
-        menu_model.append_section (null, pinned_section);
-
-        pinned_action = new SimpleAction.stateful (PINNED_ACTION, null, new Variant.boolean (pinned));
-        pinned_action.change_state.connect ((new_state) => pinned = (bool) new_state);
-        action_group.add_action (pinned_action);
 
         foreach (var action in app_info.list_actions ()) {
             var simple_action = new SimpleAction (APP_ACTION.printf (action), null);
@@ -114,11 +98,10 @@ public class Dock.App : Object {
                 var split = instance.name.split (".");
                 launch (context, split[1]);
             });
-            action_group.add_action (simple_action);
+            app_action_group.add_action (simple_action);
         }
 
         notify["pinned"].connect (() => {
-            pinned_action.set_state (pinned);
             check_remove ();
             ItemManager.get_default ().sync_pinned ();
         });

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -4,6 +4,10 @@
  */
 
 public class Dock.Launcher : BaseItem {
+    private const string ACTION_GROUP_PREFIX = "launcher";
+    private const string ACTION_PREFIX = ACTION_GROUP_PREFIX + ".";
+    private const string PINNED_ACTION = "pinned";
+
     private const int DND_TIMEOUT = 1000;
 
     private static Settings? notify_settings;
@@ -63,7 +67,20 @@ public class Dock.Launcher : BaseItem {
     }
 
     construct {
-        popover_menu = new Gtk.PopoverMenu.from_model (app.menu_model) {
+        var action_group = new SimpleActionGroup ();
+        action_group.add_action (new PropertyAction (PINNED_ACTION, app, "pinned"));
+        insert_action_group (ACTION_GROUP_PREFIX, action_group);
+
+        insert_action_group (App.ACTION_GROUP_PREFIX, app.app_action_group);
+
+        var pinned_section = new Menu ();
+        pinned_section.append (_("Keep in Dock"), ACTION_PREFIX + PINNED_ACTION);
+
+        var menu = new Menu ();
+        menu.append_section (null, app.app_action_menu);
+        menu.append_section (null, pinned_section);
+
+        popover_menu = new Gtk.PopoverMenu.from_model (menu) {
             autohide = true,
             position = TOP
         };
@@ -120,8 +137,6 @@ public class Dock.Launcher : BaseItem {
         };
 
         insert_child_after (running_revealer, bin);
-
-        insert_action_group (App.ACTION_GROUP_PREFIX, app.action_group);
 
         // We have to destroy the progressbar when it is not needed otherwise it will
         // cause continuous layouting of the surface see https://github.com/elementary/dock/issues/279


### PR DESCRIPTION
Fixes #520 

Menu and actions are UI stuff and not model stuff so move the pinned action and the main menu model to launcher. Make the pinned action a property action there. PropertyAction keeps a reference on the object whose property it represents so it shouldnt be in the same class because that would form a reference cycle. Also using property action means the property has to be public set anyways so IMO the property action should be created by its consumer which is in this case the launcher (the app shouldn't have to care about how pinned is set).

Closes #508 