### PR TITLE
Introduce an ItemGroup

### DIFF
--- a/src/AppSystem/Background/BackgroundItem.vala
+++ b/src/AppSystem/Background/BackgroundItem.vala
@@ -6,10 +6,9 @@
  */
 
 public class Dock.BackgroundItem : BaseIconGroup {
-    public signal void apps_appeared ();
-
     public BackgroundMonitor monitor { private get; construct; }
     public bool has_apps { get { return monitor.background_apps.get_n_items () > 0; } }
+    public ListStore item_group_store { get; private set; }
 
     public BackgroundItem () {
         var background_monitor = new BackgroundMonitor ();
@@ -23,6 +22,8 @@ public class Dock.BackgroundItem : BaseIconGroup {
     }
 
     construct {
+        item_group_store = new ListStore (typeof (BackgroundItem));
+
         var list_box = new Gtk.ListBox () {
             selection_mode = BROWSE
         };
@@ -67,9 +68,9 @@ public class Dock.BackgroundItem : BaseIconGroup {
         monitor.background_apps.items_changed.connect ((pos, n_removed, n_added) => {
             if (monitor.background_apps.get_n_items () == 0) {
                 popover_menu.popdown ();
-                removed ();
+                item_group_store.remove (0);
             } else if (n_removed == 0 && n_added != 0 && n_added == monitor.background_apps.get_n_items ()) {
-                apps_appeared ();
+                item_group_store.append (this);
             }
         });
 

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -134,7 +134,7 @@ public class Dock.BaseItem : Gtk.Box {
         reveal.done.connect (set_revealed_finish);
 
         var animation_target = new Adw.CallbackAnimationTarget ((val) => {
-            ItemManager.get_default ().move (this, val, 0);
+            ((Gtk.Fixed) parent).move (this, val, 0);
             current_pos = val;
         });
 
@@ -225,6 +225,10 @@ public class Dock.BaseItem : Gtk.Box {
      * when moving a launcher so that its current_pos is always up to date.
      */
     public void animate_move (double new_position) {
+        if (timed_animation.value_to == new_position) {
+            return;
+        }
+
         timed_animation.value_from = current_pos;
         timed_animation.value_to = new_position;
 

--- a/src/ItemGroup.vala
+++ b/src/ItemGroup.vala
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+ public class Dock.ItemGroup : Gtk.Fixed {
+    private static Settings settings;
+
+    public ListModel items { get; construct; }
+
+    private Sequence<BaseItem> item_store;
+    private ListStore current_children;
+
+    private Adw.TimedAnimation resize_animation;
+
+    private bool relayout_queued = false;
+
+    public ItemGroup (ListModel items) {
+        Object (items: items);
+    }
+
+    static construct {
+        settings = new Settings ("io.elementary.dock");
+    }
+
+    construct {
+        item_store = new Sequence<BaseItem> ();
+
+        current_children = new ListStore (typeof (BaseItem));
+        current_children.items_changed.connect (queue_relayout);
+
+        settings.changed["icon-size"].connect (queue_relayout);
+
+        var animation_target = new Adw.PropertyAnimationTarget (this, "width-request");
+
+        resize_animation = new Adw.TimedAnimation (this, 0, 0, Granite.TRANSITION_DURATION_OPEN, animation_target);
+        resize_animation.done.connect (on_resized);
+
+        items.items_changed.connect (on_items_changed);
+        on_items_changed (0, 0, items.get_n_items ());
+
+        overflow = VISIBLE;
+    }
+
+    private void queue_relayout () {
+        if (relayout_queued) {
+            return;
+        }
+
+        relayout_queued = true;
+        Idle.add_once (relayout);
+    }
+
+    private void relayout () {
+        resize_animation.value_from = width_request;
+        resize_animation.value_to = get_launcher_size () * current_children.get_n_items ();
+        resize_animation.duration = resize_animation.value_from < resize_animation.value_to ?
+            Granite.TRANSITION_DURATION_OPEN : Granite.TRANSITION_DURATION_CLOSE;
+        resize_animation.play ();
+
+        for (uint i = 0; i < current_children.get_n_items (); i++) {
+            var item = (BaseItem) current_children.get_item (i);
+            item.animate_move (get_launcher_size () * i);
+        }
+
+        relayout_queued = false;
+    }
+
+    private static int get_launcher_size () {
+        return settings.get_int ("icon-size") + Launcher.PADDING * 2;
+    }
+
+    private void on_resized () {
+        // When we finished resizing we know we now have enough space for all new items
+        // so reveal them
+        for (uint i = 0; i < current_children.get_n_items (); i++) {
+            var item = (BaseItem) current_children.get_item (i);
+            if (!item.visible) {
+                item.visible = true;
+                item.set_revealed (true);
+            }
+        }
+    }
+
+    private void on_items_changed (uint position, uint removed, uint added) {
+        var start_iter = item_store.get_iter_at_pos ((int) position);
+        var end_iter = start_iter.move ((int) removed);
+        start_iter.foreach_range (end_iter, remove_item);
+        start_iter.remove_range (end_iter);
+
+        var insert_iter = item_store.get_iter_at_pos ((int) position);
+        for (int i = (int) position; i < position + added; i++) {
+            var item = (BaseItem) items.get_item (i);
+            insert_iter.insert_before (item);
+
+            add_item (i, item);
+        }
+    }
+
+    private void add_item (int pos, BaseItem item) {
+        if (item.parent == this) {
+            // The item was already in this group and is currently being removed
+            // so immediately finish the removal and add it as if it was new
+            // This happens when the items are repositioned via dnd
+            finish_remove (item);
+        }
+
+        item.visible = false;
+
+        var item_pos = get_launcher_size () * pos;
+        put (item, item_pos, 0);
+        item.current_pos = item_pos;
+
+        current_children.insert (pos, item);
+    }
+
+    private void remove_item (BaseItem item) {
+        item.revealed_done.connect (finish_remove);
+        item.set_revealed (false);
+    }
+
+    private void finish_remove (BaseItem item) {
+        item.revealed_done.disconnect (finish_remove);
+
+        remove (item);
+
+        uint index;
+        if (current_children.find (item, out index)) {
+            current_children.remove (index);
+        }
+    }
+}

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2023-2025 elementary, Inc. (https://elementary.io)
  */
 
- public class Dock.ItemManager : Gtk.Fixed {
+ public class Dock.ItemManager : Gtk.Box {
     private static Settings settings;
 
     private static GLib.Once<ItemManager> instance;
@@ -13,10 +13,9 @@
 
     public Launcher? added_launcher { get; set; default = null; }
 
-    private Adw.TimedAnimation resize_animation;
-    private GLib.GenericArray<Launcher> launchers; // Only used to keep track of launcher indices
+    private ListStore launchers;
     private BackgroundItem background_item;
-    private GLib.GenericArray<WorkspaceIconGroup> icon_groups; // Only used to keep track of icon group indices
+    private ListStore icon_groups; // Only used to keep track of icon group indices
     private DynamicWorkspaceIcon dynamic_workspace_item;
 
 #if WORKSPACE_SWITCHER
@@ -28,33 +27,30 @@
     }
 
     construct {
-        launchers = new GLib.GenericArray<Launcher> ();
+        launchers = new ListStore (typeof (Launcher));
 
         background_item = new BackgroundItem ();
-        background_item.apps_appeared.connect (add_item);
 
-        icon_groups = new GLib.GenericArray<WorkspaceIconGroup> ();
+        icon_groups = new ListStore (typeof (WorkspaceIconGroup));
 
 #if WORKSPACE_SWITCHER
         dynamic_workspace_item = new DynamicWorkspaceIcon ();
 
-        separator = new Gtk.Separator (VERTICAL);
+        separator = new Gtk.Separator (VERTICAL) {
+            valign = START,
+            margin_top = Launcher.PADDING,
+        };
         settings.bind ("icon-size", separator, "height-request", GET);
-        put (separator, 0, 0);
 #endif
 
+        append (new ItemGroup (launchers));
+        append (new ItemGroup (background_item.item_group_store));
+#if WORKSPACE_SWITCHER
+        append (separator);
+        append (new ItemGroup (icon_groups));
+        append (dynamic_workspace_item);
+#endif
         overflow = VISIBLE;
-
-        resize_animation = new Adw.TimedAnimation (
-            this, 0, 0, 0,
-            new Adw.CallbackAnimationTarget ((val) => {
-                width_request = (int) val;
-            })
-        );
-
-        resize_animation.done.connect (() => width_request = -1); //Reset otherwise we stay to big when the launcher icon size changes
-
-        settings.changed["icon-size"].connect (reposition_items);
 
         var drop_target_file = new Gtk.DropTarget (typeof (File), COPY) {
             preload = true
@@ -175,49 +171,10 @@
         });
     }
 
-    private void reposition_items () {
-        int index = 0;
-        foreach (var launcher in launchers) {
-            position_item (launcher, ref index);
-        }
-
-        if (background_item.has_apps) {
-            position_item (background_item, ref index);
-        }
-
-#if WORKSPACE_SWITCHER
-        var separator_y = (get_launcher_size () - separator.height_request) / 2;
-        move (separator, index * get_launcher_size () - 1, separator_y);
-#endif
-
-        foreach (var icon_group in icon_groups) {
-            position_item (icon_group, ref index);
-        }
-
-#if WORKSPACE_SWITCHER
-        position_item (dynamic_workspace_item, ref index);
-#endif
-    }
-
-    private void position_item (BaseItem item, ref int index) {
-        var position = get_launcher_size () * index;
-
-        if (item.parent != this) {
-            put (item, position, 0);
-            item.current_pos = position;
-        } else {
-            item.animate_move (position);
-        }
-
-        index++;
-    }
-
     private void add_launcher_via_dnd (Launcher launcher, int index) {
         launcher.removed.connect (remove_item);
 
         launchers.insert (index, launcher);
-        reposition_items ();
-        launcher.set_revealed (true);
         sync_pinned ();
     }
 
@@ -225,85 +182,46 @@
         item.removed.connect (remove_item);
 
         if (item is Launcher) {
-            launchers.add ((Launcher) item);
+            launchers.append (item);
             sync_pinned ();
         } else if (item is WorkspaceIconGroup) {
-            icon_groups.add ((WorkspaceIconGroup) item);
+            icon_groups.append (item);
         }
-
-        ulong reveal_cb = 0;
-        reveal_cb = resize_animation.done.connect (() => {
-            resize_animation.disconnect (reveal_cb);
-            reposition_items ();
-            item.set_revealed (true);
-        });
-
-        resize_animation.easing = EASE_OUT_BACK;
-        resize_animation.duration = Granite.TRANSITION_DURATION_OPEN;
-        resize_animation.value_from = get_width ();
-        resize_animation.value_to = launchers.length * get_launcher_size ();
-        resize_animation.play ();
     }
 
     private void remove_item (BaseItem item) {
+        ListStore store;
         if (item is Launcher) {
-            launchers.remove ((Launcher) item);
+            store = launchers;
         } else if (item is WorkspaceIconGroup) {
-            icon_groups.remove ((WorkspaceIconGroup) item);
+            store = icon_groups;
+        } else {
+            return;
+        }
+
+        uint index;
+        if (store.find (item, out index)) {
+            store.remove (index);
         }
 
         item.removed.disconnect (remove_item);
-        item.revealed_done.connect (remove_finish);
-        item.set_revealed (false);
-    }
-
-    private void remove_finish (BaseItem item) {
-        // Temporarily set the width request to avoid flicker until the animation calls the callback for the first time
-        width_request = get_width ();
-
-        remove (item);
-        reposition_items ();
-
-        resize_animation.easing = EASE_IN_OUT_QUAD;
-        resize_animation.duration = Granite.TRANSITION_DURATION_CLOSE;
-        resize_animation.value_from = get_width ();
-        resize_animation.value_to = launchers.length * get_launcher_size ();
-        resize_animation.play ();
-
-        item.revealed_done.disconnect (remove_finish);
         item.cleanup ();
     }
 
     public void move_launcher_after (BaseItem source, int target_index) {
-        unowned GLib.GenericArray<BaseItem>? list = null;
-        double offset = 0;
+        ListStore list;
         if (source is Launcher) {
             list = launchers;
         } else if (source is WorkspaceIconGroup) {
             list = icon_groups;
-            offset = (launchers.length + (background_item.has_apps ? 1 : 0)) * get_launcher_size (); // +1 for the background item
         } else {
             warning ("Tried to move neither launcher nor icon group");
             return;
         }
 
-        if (target_index >= list.length) {
-            target_index = list.length - 1;
-        }
+        var source_index = get_index_for_launcher (source);
 
-        uint source_index = 0;
-        list.find (source, out source_index);
-
-        source.animate_move ((get_launcher_size () * target_index) + offset);
-
-        bool right = source_index > target_index;
-
-        // Move the launchers located between the source and the target with an animation
-        for (int i = (right ? target_index : (int) (source_index + 1)); i <= (right ? ((int) source_index) - 1 : target_index); i++) {
-            list.get (i).animate_move ((right ? (i + 1) * get_launcher_size () : (i - 1) * get_launcher_size ()) + offset);
-        }
-
-        list.remove (source);
+        list.remove ((uint) source_index);
         list.insert (target_index, source);
 
         sync_pinned ();
@@ -325,7 +243,7 @@
 
             return 0;
         } else if (item == dynamic_workspace_item) { //treat dynamic workspace icon as last icon group
-            return (int) icon_groups.length;
+            return (int) icon_groups.get_n_items ();
         }
 
         warning ("Tried to get index of neither launcher nor icon group");
@@ -335,7 +253,8 @@
     public void sync_pinned () {
         string[] new_pinned_ids = {};
 
-        foreach (var launcher in launchers) {
+        for (uint i = 0; i < launchers.get_n_items (); i++) {
+            var launcher = (Launcher) launchers.get_item (i);
             if (launcher.app.pinned) {
                 new_pinned_ids += launcher.app.app_info.get_id ();
             }
@@ -345,12 +264,13 @@
     }
 
     public void launch (uint index) {
-        if (index < 1 || index > launchers.length) {
+        if (index < 1 || index > launchers.get_n_items ()) {
             return;
         }
 
         var context = Gdk.Display.get_default ().get_app_launch_context ();
-        launchers.get ((int) index - 1).app.launch (context);
+        var launcher = (Launcher) launchers.get_item (index - 1);
+        launcher.app.launch (context);
     }
 
     public static int get_launcher_size () {

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ sources = [
     'BaseItem.vala',
     'BottomMargin.vala',
     'ContainerItem.vala',
+    'ItemGroup.vala',
     'ItemManager.vala',
     'MainWindow.vala',
     'RenderNodeWalker.vala',


### PR DESCRIPTION
Instead of having one big Gtk.Fixed with all of the launchers, separator, workspace, etc. introduce an ItemGroup class which holds the items of one group and add them together in a gtk.box. The ItemGroup works with a listmodel.
This has a couple advantages.
- the resize animation now finally applies again because right now it doesn't do anything since when a launcher gets added it never is the last item with the new workspace switcher.
- this addresses #511 a bit because the 2 pixels of the separator are now actually respected in the layout. If we want to address that more this will also be much easier because we can just add margins etc. because of the next point
- This simplifies layout handling because we don't have to iterate over multiple lists now and specially layout things like the separator and the dynamic workspace item because things at fixed positions are layout by the box and in the item group we just have a single list we need to layout
- Simplifies the repositioning logic because we just treat a reposition as remove + add

To reduce the diff the listmodels are still in the main itemmanager and just relay the current mechanisms to the item group via the listmodel. Therefore the following points will be for the future:
- The item groups being based on listmodels will allow us to simplify our item management. I.e. the app system and the workspace system can just provide a listmodel with their items and we don't need to go weird routes via connecting to added signals from the systems and to removed signals from the items which connect to removed signals to their apps/workspaces
- Syncing pinned launchers is right now split between appsystem and itemmanager and can be unified in the app system
- We can get rid of all of the type checking if else ifs 