### PR TITLE
Application: rely on Granite.StyleManager

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,15 +14,6 @@ public class Dock.Application : Gtk.Application {
         Granite.init ();
         ShellKeyGrabber.init ();
         GalaDBus.init.begin ();
-
-        unowned var granite_settings = Granite.Settings.get_default ();
-        unowned var gtk_settings = Gtk.Settings.get_default ();
-
-        granite_settings.notify["prefers-color-scheme"].connect (() =>
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK
-        );
-
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
     }
 
     protected override void activate () {


### PR DESCRIPTION
Granite.StyleManager handles dark mode since 7.7.0