### PR TITLE
Use ListModels

### DIFF
--- a/src/AppSystem/App.vala
+++ b/src/AppSystem/App.vala
@@ -125,7 +125,6 @@ public class Dock.App : Object {
 
         notify["pinned"].connect (() => {
             check_remove ();
-            ItemManager.get_default ().sync_pinned ();
         });
 
         WindowSystem.get_default ().notify["active-workspace"].connect (() => {

--- a/src/AppSystem/Background/BackgroundItem.vala
+++ b/src/AppSystem/Background/BackgroundItem.vala
@@ -6,10 +6,10 @@
  */
 
 public class Dock.BackgroundItem : BaseIconGroup {
-    public signal void apps_appeared ();
+    private ListStore group_store;
+    public ListModel group_model { get { return group_store; } }
 
     public BackgroundMonitor monitor { private get; construct; }
-    public bool has_apps { get { return monitor.background_apps.get_n_items () > 0; } }
 
     public BackgroundItem () {
         var background_monitor = new BackgroundMonitor ();
@@ -23,6 +23,8 @@ public class Dock.BackgroundItem : BaseIconGroup {
     }
 
     construct {
+        group_store = new ListStore (typeof (BackgroundItem));
+
         var list_box = new Gtk.ListBox () {
             selection_mode = BROWSE
         };
@@ -67,9 +69,9 @@ public class Dock.BackgroundItem : BaseIconGroup {
         monitor.background_apps.items_changed.connect ((pos, n_removed, n_added) => {
             if (monitor.background_apps.get_n_items () == 0) {
                 popover_menu.popdown ();
-                removed ();
+                group_store.remove (0);
             } else if (n_removed == 0 && n_added != 0 && n_added == monitor.background_apps.get_n_items ()) {
-                apps_appeared ();
+                group_store.append (this);
             }
         });
 

--- a/src/AppSystem/Background/BackgroundItem.vala
+++ b/src/AppSystem/Background/BackgroundItem.vala
@@ -18,7 +18,7 @@ public class Dock.BackgroundItem : BaseIconGroup {
             icons: new Gtk.MapListModel (background_monitor.background_apps, (app) => {
                 return ((BackgroundApp) app).icon;
             }),
-            disallow_dnd: true
+            group: Group.NONE
         );
     }
 

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -157,7 +157,6 @@ public class Dock.Launcher : BaseItem {
         });
 
         app.launched.connect (animate_launch);
-        app.removed.connect (() => removed ());
 
         var bounce_animation_target = new Adw.CallbackAnimationTarget ((val) => {
             var height = overlay.get_height ();

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -134,7 +134,7 @@ public class Dock.BaseItem : Gtk.Box {
         reveal.done.connect (set_revealed_finish);
 
         var animation_target = new Adw.CallbackAnimationTarget ((val) => {
-            ItemManager.get_default ().move (this, val, 0);
+            ((Gtk.Fixed) parent).move (this, val, 0);
             current_pos = val;
         });
 
@@ -225,6 +225,10 @@ public class Dock.BaseItem : Gtk.Box {
      * when moving a launcher so that its current_pos is always up to date.
      */
     public void animate_move (double new_position) {
+        if (timed_animation.value_to == new_position) {
+            return;
+        }
+
         timed_animation.value_from = current_pos;
         timed_animation.value_to = new_position;
 

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -22,7 +22,6 @@ public class Dock.BaseItem : Gtk.Box {
         dock_settings = new GLib.Settings ("io.elementary.dock");
     }
 
-    public signal void removed ();
     public signal void revealed_done ();
 
     /**
@@ -313,7 +312,7 @@ public class Dock.BaseItem : Gtk.Box {
 
     private bool is_allowed_drop (Value val) {
         var obj = val.get_object ();
-        return obj != null && obj is BaseItem && ((BaseItem) obj).group == group;
+        return obj != null && obj is BaseItem && ((BaseItem) obj).group == group && obj != this;
     }
 
     private class PopoverTooltip : Gtk.Popover {

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -11,6 +11,7 @@ public class Dock.BaseItem : Gtk.Box {
     }
 
     public enum Group {
+        NONE,
         LAUNCHER,
         WORKSPACE
     }
@@ -24,7 +25,6 @@ public class Dock.BaseItem : Gtk.Box {
     public signal void removed ();
     public signal void revealed_done ();
 
-    public bool disallow_dnd { get; construct; default = false; }
     /**
      * The group in the dock this item belongs to. This is used to allow DND
      * only within that group.
@@ -161,16 +161,16 @@ public class Dock.BaseItem : Gtk.Box {
         gesture_click = new Gtk.GestureClick ();
         add_controller (gesture_click);
 
+        if (group == NONE) {
+            return;
+        }
+
         var drop_target = new Gtk.DropTarget (typeof (BaseItem), MOVE) {
             preload = true
         };
         add_controller (drop_target);
         drop_target.enter.connect (on_drop_enter);
         drop_target.drop.connect (on_drop);
-
-        if (disallow_dnd) {
-            return;
-        }
 
         var drag_source = new Gtk.DragSource () {
             actions = MOVE
@@ -185,6 +185,11 @@ public class Dock.BaseItem : Gtk.Box {
     ~BaseItem () {
         popover_tooltip.unparent ();
         popover_tooltip.dispose ();
+    }
+
+    public uint get_index () {
+        var item_group = get_ancestor (typeof (ItemGroup)) as ItemGroup;
+        return item_group?.get_index_for_item (this) ?? Gtk.INVALID_LIST_POSITION;
     }
 
     public void set_revealed (bool revealed) {
@@ -295,15 +300,7 @@ public class Dock.BaseItem : Gtk.Box {
      */
     public void calculate_dnd_move (BaseItem source, double x, double y) {
         var launcher_manager = ItemManager.get_default ();
-
-        int target_index = launcher_manager.get_index_for_launcher (this);
-        int source_index = launcher_manager.get_index_for_launcher (source);
-
-        if (source_index == target_index) {
-            return;
-        }
-
-        launcher_manager.move_launcher_after (source, target_index);
+        launcher_manager.move_launcher_after (source, (int) get_index ());
     }
 
     private bool on_drop (Value val) {

--- a/src/ItemGroup.vala
+++ b/src/ItemGroup.vala
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+ public class Dock.ItemGroup : Gtk.Fixed {
+    private static Settings settings;
+
+    public ListModel items { get; construct; }
+
+    private Sequence<BaseItem> item_store;
+    private ListStore current_children;
+
+    private Adw.TimedAnimation resize_animation;
+
+    private bool relayout_queued = false;
+
+    public ItemGroup (ListModel items) {
+        Object (items: items);
+    }
+
+    static construct {
+        settings = new Settings ("io.elementary.dock");
+    }
+
+    construct {
+        item_store = new Sequence<BaseItem> ();
+
+        current_children = new ListStore (typeof (BaseItem));
+        current_children.items_changed.connect (queue_relayout);
+
+        settings.changed["icon-size"].connect (queue_relayout);
+
+        var animation_target = new Adw.PropertyAnimationTarget (this, "width-request");
+
+        resize_animation = new Adw.TimedAnimation (this, 0, 0, Granite.TRANSITION_DURATION_OPEN, animation_target);
+        resize_animation.done.connect (on_resized);
+
+        items.items_changed.connect (on_items_changed);
+        on_items_changed (0, 0, items.get_n_items ());
+
+        overflow = VISIBLE;
+    }
+
+    private void queue_relayout () {
+        if (relayout_queued) {
+            return;
+        }
+
+        relayout_queued = true;
+        Idle.add_once (relayout);
+    }
+
+    private void relayout () {
+        resize_animation.value_from = width_request;
+        resize_animation.value_to = get_launcher_size () * current_children.get_n_items ();
+        resize_animation.duration = resize_animation.value_from < resize_animation.value_to ?
+            Granite.TRANSITION_DURATION_OPEN : Granite.TRANSITION_DURATION_CLOSE;
+        resize_animation.play ();
+
+        for (uint i = 0; i < current_children.get_n_items (); i++) {
+            var item = (BaseItem) current_children.get_item (i);
+            item.animate_move (get_launcher_size () * i);
+        }
+
+        relayout_queued = false;
+    }
+
+    private static int get_launcher_size () {
+        return settings.get_int ("icon-size") + Launcher.PADDING * 2;
+    }
+
+    private void on_resized () {
+        // When we finished resizing we know we now have enough space for all new items
+        // so reveal them
+        for (uint i = 0; i < current_children.get_n_items (); i++) {
+            var item = (BaseItem) current_children.get_item (i);
+            if (!item.visible) {
+                item.visible = true;
+                item.set_revealed (true);
+            }
+        }
+    }
+
+    private void on_items_changed (uint position, uint removed, uint added) {
+        var start_iter = item_store.get_iter_at_pos ((int) position);
+        var end_iter = start_iter.move ((int) removed);
+        start_iter.foreach_range (end_iter, remove_item);
+        start_iter.remove_range (end_iter);
+
+        var insert_iter = item_store.get_iter_at_pos ((int) position);
+        for (int i = (int) position; i < position + added; i++) {
+            var item = (BaseItem) items.get_item (i);
+            insert_iter.insert_before (item);
+
+            add_item (i, item);
+        }
+    }
+
+    private void add_item (int pos, BaseItem item) {
+        if (item.parent == this) {
+            // The item was already in this group and is currently being removed
+            // so immediately finish the removal and add it as if it was new
+            // This happens when the items are repositioned via dnd
+            finish_remove (item);
+        }
+
+        item.visible = false;
+
+        var item_pos = get_launcher_size () * pos;
+        put (item, item_pos, 0);
+        item.current_pos = item_pos;
+
+        current_children.insert (pos, item);
+    }
+
+    private void remove_item (BaseItem item) {
+        item.revealed_done.connect (finish_remove);
+        item.set_revealed (false);
+    }
+
+    private void finish_remove (BaseItem item) {
+        item.revealed_done.disconnect (finish_remove);
+
+        remove (item);
+
+        uint index;
+        if (current_children.find (item, out index)) {
+            current_children.remove (index);
+        }
+    }
+}

--- a/src/ItemGroup.vala
+++ b/src/ItemGroup.vala
@@ -131,4 +131,13 @@
             current_children.remove (index);
         }
     }
+
+    public uint get_index_for_item (BaseItem item) {
+        uint index;
+        if (current_children.find (item, out index)) {
+            return index;
+        }
+
+        return Gtk.INVALID_LIST_POSITION;
+    }
 }

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -210,45 +210,16 @@
     }
 
     public void move_launcher_after (BaseItem source, int target_index) {
-        ListStore list;
         if (source is Launcher) {
-            list = launchers;
+            launchers.remove ((uint) source.get_index ());
+            launchers.insert (target_index, source);
+            sync_pinned ();
         } else if (source is WorkspaceIconGroup) {
-            list = icon_groups;
+            icon_groups.remove ((uint) source.get_index ());
+            icon_groups.insert (target_index, source);
         } else {
             warning ("Tried to move neither launcher nor icon group");
-            return;
         }
-
-        var source_index = get_index_for_launcher (source);
-
-        list.remove ((uint) source_index);
-        list.insert (target_index, source);
-
-        sync_pinned ();
-    }
-
-    public int get_index_for_launcher (BaseItem item) {
-        if (item is Launcher) {
-            uint index;
-            if (launchers.find ((Launcher) item, out index)) {
-                return (int) index;
-            }
-
-            return 0;
-        } else if (item is WorkspaceIconGroup) {
-            uint index;
-            if (icon_groups.find ((WorkspaceIconGroup) item, out index)) {
-                return (int) index;
-            }
-
-            return 0;
-        } else if (item == dynamic_workspace_item) { //treat dynamic workspace icon as last icon group
-            return (int) icon_groups.get_n_items ();
-        }
-
-        warning ("Tried to get index of neither launcher nor icon group");
-        return 0;
     }
 
     public void sync_pinned () {

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2023-2025 elementary, Inc. (https://elementary.io)
  */
 
- public class Dock.ItemManager : Gtk.Fixed {
+ public class Dock.ItemManager : Gtk.Box {
     private static Settings settings;
 
     private static GLib.Once<ItemManager> instance;
@@ -13,10 +13,9 @@
 
     public Launcher? added_launcher { get; set; default = null; }
 
-    private Adw.TimedAnimation resize_animation;
-    private GLib.GenericArray<Launcher> launchers; // Only used to keep track of launcher indices
+    private ListStore launchers;
     private BackgroundItem background_item;
-    private GLib.GenericArray<WorkspaceIconGroup> icon_groups; // Only used to keep track of icon group indices
+    private ListStore icon_groups; // Only used to keep track of icon group indices
     private DynamicWorkspaceIcon dynamic_workspace_item;
 
 #if WORKSPACE_SWITCHER
@@ -28,33 +27,31 @@
     }
 
     construct {
-        launchers = new GLib.GenericArray<Launcher> ();
+        launchers = new ListStore (typeof (Launcher));
 
         background_item = new BackgroundItem ();
         background_item.apps_appeared.connect (add_item);
 
-        icon_groups = new GLib.GenericArray<WorkspaceIconGroup> ();
+        icon_groups = new ListStore (typeof (WorkspaceIconGroup));
 
 #if WORKSPACE_SWITCHER
         dynamic_workspace_item = new DynamicWorkspaceIcon ();
 
-        separator = new Gtk.Separator (VERTICAL);
+        separator = new Gtk.Separator (VERTICAL) {
+            valign = START,
+            margin_top = Launcher.PADDING,
+        };
         settings.bind ("icon-size", separator, "height-request", GET);
-        put (separator, 0, 0);
 #endif
 
+        append (new ItemGroup (launchers));
+        append (background_item);
+#if WORKSPACE_SWITCHER
+        append (separator);
+        append (new ItemGroup (icon_groups));
+        append (dynamic_workspace_item);
+#endif
         overflow = VISIBLE;
-
-        resize_animation = new Adw.TimedAnimation (
-            this, 0, 0, 0,
-            new Adw.CallbackAnimationTarget ((val) => {
-                width_request = (int) val;
-            })
-        );
-
-        resize_animation.done.connect (() => width_request = -1); //Reset otherwise we stay to big when the launcher icon size changes
-
-        settings.changed["icon-size"].connect (reposition_items);
 
         var drop_target_file = new Gtk.DropTarget (typeof (File), COPY) {
             preload = true
@@ -175,49 +172,10 @@
         });
     }
 
-    private void reposition_items () {
-        int index = 0;
-        foreach (var launcher in launchers) {
-            position_item (launcher, ref index);
-        }
-
-        if (background_item.has_apps) {
-            position_item (background_item, ref index);
-        }
-
-#if WORKSPACE_SWITCHER
-        var separator_y = (get_launcher_size () - separator.height_request) / 2;
-        move (separator, index * get_launcher_size () - 1, separator_y);
-#endif
-
-        foreach (var icon_group in icon_groups) {
-            position_item (icon_group, ref index);
-        }
-
-#if WORKSPACE_SWITCHER
-        position_item (dynamic_workspace_item, ref index);
-#endif
-    }
-
-    private void position_item (BaseItem item, ref int index) {
-        var position = get_launcher_size () * index;
-
-        if (item.parent != this) {
-            put (item, position, 0);
-            item.current_pos = position;
-        } else {
-            item.animate_move (position);
-        }
-
-        index++;
-    }
-
     private void add_launcher_via_dnd (Launcher launcher, int index) {
         launcher.removed.connect (remove_item);
 
         launchers.insert (index, launcher);
-        reposition_items ();
-        launcher.set_revealed (true);
         sync_pinned ();
     }
 
@@ -225,85 +183,46 @@
         item.removed.connect (remove_item);
 
         if (item is Launcher) {
-            launchers.add ((Launcher) item);
+            launchers.append (item);
             sync_pinned ();
         } else if (item is WorkspaceIconGroup) {
-            icon_groups.add ((WorkspaceIconGroup) item);
+            icon_groups.append (item);
         }
-
-        ulong reveal_cb = 0;
-        reveal_cb = resize_animation.done.connect (() => {
-            resize_animation.disconnect (reveal_cb);
-            reposition_items ();
-            item.set_revealed (true);
-        });
-
-        resize_animation.easing = EASE_OUT_BACK;
-        resize_animation.duration = Granite.TRANSITION_DURATION_OPEN;
-        resize_animation.value_from = get_width ();
-        resize_animation.value_to = launchers.length * get_launcher_size ();
-        resize_animation.play ();
     }
 
     private void remove_item (BaseItem item) {
+        ListStore store;
         if (item is Launcher) {
-            launchers.remove ((Launcher) item);
+            store = launchers;
         } else if (item is WorkspaceIconGroup) {
-            icon_groups.remove ((WorkspaceIconGroup) item);
+            store = icon_groups;
+        } else {
+            return;
+        }
+
+        uint index;
+        if (store.find (item, out index)) {
+            store.remove (index);
         }
 
         item.removed.disconnect (remove_item);
-        item.revealed_done.connect (remove_finish);
-        item.set_revealed (false);
-    }
-
-    private void remove_finish (BaseItem item) {
-        // Temporarily set the width request to avoid flicker until the animation calls the callback for the first time
-        width_request = get_width ();
-
-        remove (item);
-        reposition_items ();
-
-        resize_animation.easing = EASE_IN_OUT_QUAD;
-        resize_animation.duration = Granite.TRANSITION_DURATION_CLOSE;
-        resize_animation.value_from = get_width ();
-        resize_animation.value_to = launchers.length * get_launcher_size ();
-        resize_animation.play ();
-
-        item.revealed_done.disconnect (remove_finish);
         item.cleanup ();
     }
 
     public void move_launcher_after (BaseItem source, int target_index) {
-        unowned GLib.GenericArray<BaseItem>? list = null;
-        double offset = 0;
+        ListStore list;
         if (source is Launcher) {
             list = launchers;
         } else if (source is WorkspaceIconGroup) {
             list = icon_groups;
-            offset = (launchers.length + (background_item.has_apps ? 1 : 0)) * get_launcher_size (); // +1 for the background item
         } else {
             warning ("Tried to move neither launcher nor icon group");
             return;
         }
 
-        if (target_index >= list.length) {
-            target_index = list.length - 1;
-        }
+        var source_index = get_index_for_launcher (source);
 
-        uint source_index = 0;
-        list.find (source, out source_index);
-
-        source.animate_move ((get_launcher_size () * target_index) + offset);
-
-        bool right = source_index > target_index;
-
-        // Move the launchers located between the source and the target with an animation
-        for (int i = (right ? target_index : (int) (source_index + 1)); i <= (right ? ((int) source_index) - 1 : target_index); i++) {
-            list.get (i).animate_move ((right ? (i + 1) * get_launcher_size () : (i - 1) * get_launcher_size ()) + offset);
-        }
-
-        list.remove (source);
+        list.remove ((uint) source_index);
         list.insert (target_index, source);
 
         sync_pinned ();
@@ -325,7 +244,7 @@
 
             return 0;
         } else if (item == dynamic_workspace_item) { //treat dynamic workspace icon as last icon group
-            return (int) icon_groups.length;
+            return (int) icon_groups.get_n_items ();
         }
 
         warning ("Tried to get index of neither launcher nor icon group");
@@ -335,7 +254,8 @@
     public void sync_pinned () {
         string[] new_pinned_ids = {};
 
-        foreach (var launcher in launchers) {
+        for (uint i = 0; i < launchers.get_n_items (); i++) {
+            var launcher = (Launcher) launchers.get_item (i);
             if (launcher.app.pinned) {
                 new_pinned_ids += launcher.app.app_info.get_id ();
             }
@@ -345,12 +265,13 @@
     }
 
     public void launch (uint index) {
-        if (index < 1 || index > launchers.length) {
+        if (index < 1 || index > launchers.get_n_items ()) {
             return;
         }
 
         var context = Gdk.Display.get_default ().get_app_launch_context ();
-        launchers.get ((int) index - 1).app.launch (context);
+        var launcher = (Launcher) launchers.get_item (index - 1);
+        launcher.app.launch (context);
     }
 
     public static int get_launcher_size () {

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -13,9 +13,6 @@
 
     public Launcher? added_launcher { get; set; default = null; }
 
-    private ListStore launchers;
-    private BackgroundItem background_item;
-    private ListStore icon_groups; // Only used to keep track of icon group indices
     private DynamicWorkspaceIcon dynamic_workspace_item;
 
 #if WORKSPACE_SWITCHER
@@ -27,12 +24,10 @@
     }
 
     construct {
-        launchers = new ListStore (typeof (Launcher));
+        var app_group = new ItemGroup (AppSystem.get_default ().apps, (obj) => new Launcher ((App) obj));
 
-        background_item = new BackgroundItem ();
-        background_item.apps_appeared.connect (add_item);
-
-        icon_groups = new ListStore (typeof (WorkspaceIconGroup));
+        var background_item = new BackgroundItem ();
+        var background_group = new ItemGroup (background_item.group_model, (obj) => (BackgroundItem) obj);
 
 #if WORKSPACE_SWITCHER
         dynamic_workspace_item = new DynamicWorkspaceIcon ();
@@ -44,11 +39,11 @@
         settings.bind ("icon-size", separator, "height-request", GET);
 #endif
 
-        append (new ItemGroup (launchers));
-        append (background_item);
+        append (app_group);
+        append (background_group);
 #if WORKSPACE_SWITCHER
         append (separator);
-        append (new ItemGroup (icon_groups));
+        append (new ItemGroup (WorkspaceSystem.get_default ().workspaces, (obj) => new WorkspaceIconGroup ((Workspace) obj)));
         append (dynamic_workspace_item);
 #endif
         overflow = VISIBLE;
@@ -94,7 +89,15 @@
                 return;
             }
 
-            app_system.add_app_for_id (app_info.get_id ());
+            app = app_system.add_app_for_id (app_info.get_id ());
+
+            for (var child = app_group.get_first_child (); child != null; child = child.get_next_sibling ()) {
+                if (child is Launcher && child.app == app) {
+                    added_launcher = (Launcher) child;
+                    added_launcher.moving = true;
+                    break;
+                }
+            }
         });
 
         BaseItem? current_base_item = null;
@@ -142,27 +145,6 @@
             return false;
         });
 
-        AppSystem.get_default ().app_added.connect ((app) => {
-            var launcher = new Launcher (app);
-
-            if (drop_target_file.get_value () != null && added_launcher == null) { // The launcher is being added via dnd from wingpanel
-                var position = (int) Math.round (drop_x / get_launcher_size ());
-                added_launcher = launcher;
-                launcher.moving = true;
-
-                add_launcher_via_dnd (launcher, position);
-                return;
-            }
-
-            add_item (launcher);
-        });
-
-#if WORKSPACE_SWITCHER
-        WorkspaceSystem.get_default ().workspace_added.connect ((workspace) => {
-            add_item (new WorkspaceIconGroup (workspace));
-        });
-#endif
-
         map.connect (() => {
             AppSystem.get_default ().load.begin ();
             background_item.load ();
@@ -172,77 +154,24 @@
         });
     }
 
-    private void add_launcher_via_dnd (Launcher launcher, int index) {
-        launcher.removed.connect (remove_item);
-
-        launchers.insert (index, launcher);
-        sync_pinned ();
-    }
-
-    private void add_item (BaseItem item) {
-        item.removed.connect (remove_item);
-
-        if (item is Launcher) {
-            launchers.append (item);
-            sync_pinned ();
-        } else if (item is WorkspaceIconGroup) {
-            icon_groups.append (item);
-        }
-    }
-
-    private void remove_item (BaseItem item) {
-        ListStore store;
-        if (item is Launcher) {
-            store = launchers;
-        } else if (item is WorkspaceIconGroup) {
-            store = icon_groups;
-        } else {
-            return;
-        }
-
-        uint index;
-        if (store.find (item, out index)) {
-            store.remove (index);
-        }
-
-        item.removed.disconnect (remove_item);
-        item.cleanup ();
-    }
-
     public void move_launcher_after (BaseItem source, int target_index) {
         if (source is Launcher) {
-            launchers.remove ((uint) source.get_index ());
-            launchers.insert (target_index, source);
-            sync_pinned ();
+            AppSystem.get_default ().reorder_app (source.app, target_index);
         } else if (source is WorkspaceIconGroup) {
-            icon_groups.remove ((uint) source.get_index ());
-            icon_groups.insert (target_index, source);
+            WorkspaceSystem.get_default ().reorder_workspace (source.workspace, target_index);
         } else {
             warning ("Tried to move neither launcher nor icon group");
         }
     }
 
-    public void sync_pinned () {
-        string[] new_pinned_ids = {};
-
-        for (uint i = 0; i < launchers.get_n_items (); i++) {
-            var launcher = (Launcher) launchers.get_item (i);
-            if (launcher.app.pinned) {
-                new_pinned_ids += launcher.app.app_info.get_id ();
-            }
-        }
-
-        settings.set_strv ("launchers", new_pinned_ids);
-    }
-
     public void launch (uint index) {
-        if (index < 1 || index > launchers.get_n_items ()) {
+        if (index < 1 || index > AppSystem.get_default ().apps.get_n_items ()) {
             return;
         }
 
         var context = Gdk.Display.get_default ().get_app_launch_context ();
-        var launcher = (Launcher) launchers.get_item (index - 1);
-        launcher.app.launch (context);
+        var app = (App) AppSystem.get_default ().apps.get_item (index - 1);
+        app.launch (context);
     }
 
     public static int get_launcher_size () {

--- a/src/WindowSystem/WindowSystem.vala
+++ b/src/WindowSystem/WindowSystem.vala
@@ -42,11 +42,10 @@
     }
 
     public Window? find_window (uint64 uid) {
-        uint index;
-        if (windows.find_custom (uid, (win, uid) => {
-            return win.uid == (uint64) uid;
-        }, out index)) {
-            return windows[index];
+        foreach (var window in windows) {
+            if (window.uid == uid) {
+                return window;
+            }
         }
 
         return null;

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -4,7 +4,7 @@
  */
 
 public class Dock.DynamicWorkspaceIcon : ContainerItem, WorkspaceItem {
-    public int workspace_index { get { return WorkspaceSystem.get_default ().workspaces.length; } }
+    public int workspace_index { get { return (int) WorkspaceSystem.get_default ().workspaces.get_n_items (); } }
 
     private Gtk.Image image;
 
@@ -27,8 +27,7 @@ public class Dock.DynamicWorkspaceIcon : ContainerItem, WorkspaceItem {
             _("New Workspace")
         );
 
-        WorkspaceSystem.get_default ().workspace_added.connect (update_active_state);
-        WorkspaceSystem.get_default ().workspace_removed.connect (update_active_state);
+        WorkspaceSystem.get_default ().workspaces.items_changed.connect (update_active_state);
         WindowSystem.get_default ().notify["active-workspace"].connect (update_active_state);
 
         dock_settings.bind_with_mapping (
@@ -51,11 +50,11 @@ public class Dock.DynamicWorkspaceIcon : ContainerItem, WorkspaceItem {
     private void update_active_state () {
         unowned var workspace_system = WorkspaceSystem.get_default ();
         unowned var window_system = WindowSystem.get_default ();
-        state = (workspace_system.workspaces.length == window_system.active_workspace) ? State.ACTIVE : State.HIDDEN;
+        state = (workspace_system.workspaces.get_n_items () == window_system.active_workspace) ? State.ACTIVE : State.HIDDEN;
     }
 
     private async void switch_to_new_workspace () {
-        var n_workspaces = WorkspaceSystem.get_default ().workspaces.length;
+        var n_workspaces = (int) WorkspaceSystem.get_default ().workspaces.get_n_items ();
         var index = WindowSystem.get_default ().active_workspace;
 
         if (index == n_workspaces) {

--- a/src/WorkspaceSystem/DynamicWorkspaceItem.vala
+++ b/src/WorkspaceSystem/DynamicWorkspaceItem.vala
@@ -9,7 +9,7 @@ public class Dock.DynamicWorkspaceIcon : ContainerItem, WorkspaceItem {
     private Gtk.Image image;
 
     public DynamicWorkspaceIcon () {
-        Object (disallow_dnd: true, group: Group.WORKSPACE);
+        Object (group: Group.NONE);
     }
 
     construct {

--- a/src/WorkspaceSystem/IconGroup.vala
+++ b/src/WorkspaceSystem/IconGroup.vala
@@ -48,7 +48,7 @@ public class Dock.WorkspaceIconGroup : BaseIconGroup, WorkspaceItem {
 
     private void on_moving_changed () {
         if (!moving) {
-            workspace.reorder (ItemManager.get_default ().get_index_for_launcher (this));
+            workspace.reorder ((int) get_index ());
         }
     }
 

--- a/src/WorkspaceSystem/IconGroup.vala
+++ b/src/WorkspaceSystem/IconGroup.vala
@@ -38,18 +38,8 @@ public class Dock.WorkspaceIconGroup : BaseIconGroup, WorkspaceItem {
             return true;
         });
 
-        workspace.removed.connect (() => removed ());
-
         gesture_click.button = Gdk.BUTTON_PRIMARY;
         gesture_click.released.connect (workspace.activate);
-
-        notify["moving"].connect (on_moving_changed);
-    }
-
-    private void on_moving_changed () {
-        if (!moving) {
-            workspace.reorder ((int) get_index ());
-        }
     }
 
     public void window_entered (Window window) {

--- a/src/WorkspaceSystem/Workspace.vala
+++ b/src/WorkspaceSystem/Workspace.vala
@@ -4,9 +4,6 @@
  */
 
 public class Dock.Workspace : GLib.Object {
-    public signal void reordered (int new_index);
-    public signal void removed ();
-
     private ListStore store;
     public ListModel windows { get { return store; } }
     public int index { get; set; }
@@ -20,10 +17,6 @@ public class Dock.Workspace : GLib.Object {
         store.splice (0, store.get_n_items (), new_windows.data);
     }
 
-    public void remove () {
-        removed ();
-    }
-
     public void update_active_workspace () {
         is_active_workspace = index == WindowSystem.get_default ().active_workspace;
     }
@@ -34,10 +27,5 @@ public class Dock.Workspace : GLib.Object {
         } else {
             WindowSystem.get_default ().desktop_integration.activate_workspace.begin (index);
         }
-    }
-
-    public void reorder (int new_index) {
-        reordered (new_index);
-        WindowSystem.get_default ().desktop_integration.reorder_workspace.begin (index, new_index);
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ sources = [
     'BaseItem.vala',
     'BottomMargin.vala',
     'ContainerItem.vala',
+    'ItemGroup.vala',
     'ItemManager.vala',
     'MainWindow.vala',
     'RenderNodeWalker.vala',


### PR DESCRIPTION
This builds on top of #523 and allows us to provide a listmodel of objects and bind them to the itemgroup similar to how we bind listmodels to listboxes.

This has a few advantages:
- remove most of the mess in itemmanager (lots of type checking, custom layouting, work arounds)
- simplify the item handling. For example on main when a workspace is removed the workspace system receives that signal -> removes it from its internal list -> calls remove() on the workspace -> that emits the removed signal on the workspace -> the workspace icon group is connected to that and emits removed() on the baseitem -> the itemmanager had connected to that and starts removing the item. That involves 5 classes. With this branch it goes workspace system receives that signal -> removes the workspace from its internal list which is now a listmodel -> the rest is handled automatically via the items changed signal of the listmodel in the item group. That involves 2 classes.
- allows to add new sections to the dock much more easily