### PR TITLE
Handle app removal and adding only in appsystem

### DIFF
--- a/src/AppSystem/App.vala
+++ b/src/AppSystem/App.vala
@@ -23,10 +23,9 @@ public class Dock.App : Object {
         }
     }
 
-    public signal void removed ();
-
-    public bool pinned { get; construct set; }
     public GLib.DesktopAppInfo app_info { get; construct; }
+
+    public bool pinned { get; set; }
 
     public bool count_visible { get; private set; default = false; }
     public int64 current_count { get; private set; default = 0; }
@@ -59,8 +58,8 @@ public class Dock.App : Object {
 
     private string appstream_comp_id = "";
 
-    public App (GLib.DesktopAppInfo app_info, bool pinned) {
-        Object (app_info: app_info, pinned: pinned);
+    public App (GLib.DesktopAppInfo app_info) {
+        Object (app_info: app_info);
     }
 
     static construct {
@@ -123,10 +122,6 @@ public class Dock.App : Object {
             on_appcenter_dbus_changed.begin ();
         }
 
-        notify["pinned"].connect (() => {
-            check_remove ();
-        });
-
         WindowSystem.get_default ().notify["active-workspace"].connect (() => {
             notify_property ("running-on-active-workspace");
         });
@@ -187,12 +182,6 @@ public class Dock.App : Object {
         return false;
     }
 
-    private void check_remove () {
-        if (!pinned && !running) {
-            removed ();
-        }
-    }
-
     public void update_windows (GLib.GenericArray<Window>? new_windows) {
         if (new_windows == null) {
             windows = new GLib.GenericArray<Window> ();
@@ -206,8 +195,6 @@ public class Dock.App : Object {
         if (launching && running) {
             launching = false;
         }
-
-        check_remove ();
     }
 
     public void perform_unity_update (VariantIter prop_iter) {

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -82,14 +82,18 @@
 
             var app_system = AppSystem.get_default ();
 
-            var app = app_system.get_app (app_info.get_id ());
-            if (app != null) {
+            var app = app_system.get_app_by_id (app_info.get_id ());
+
+            if (app == null) {
+                return;
+            }
+
+            if (app.pinned || app.running) {
+                // Already in the dock
                 app.pinned = true;
                 drop_target_file.reject ();
                 return;
             }
-
-            app = app_system.add_app_for_id (app_info.get_id ());
 
             for (var child = app_group.get_first_child (); child != null; child = child.get_next_sibling ()) {
                 if (child is Launcher && child.app == app) {

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -77,14 +77,18 @@
 
             var app_system = AppSystem.get_default ();
 
-            var app = app_system.get_app (app_info.get_id ());
-            if (app != null) {
+            var app = app_system.get_app_by_id (app_info.get_id ());
+
+            if (app == null) {
+                return;
+            }
+
+            if (app.pinned || app.running) {
+                // Already in the dock
                 app.pinned = true;
                 drop_target_file.reject ();
                 return;
             }
-
-            app = app_system.add_app_for_id (app_info.get_id ());
 
             for (var child = app_group.get_first_child (); child != null; child = child.get_next_sibling ()) {
                 if (child is Launcher && child.app == app) {


### PR DESCRIPTION
Instead of an app emitting removed and then the appsystem removing it, the app system connects to the app property notifies and then removes it. This now also allows to get apps from the appsystem without adding them to the dock. This will be useful in the future (e.g. appmenu/smart suggestions) to make sure only a single app object exists for an app with a given id. The appsystem will then act kind of like an repository and it connects to the signals and adds them to the dock once they should be in the dock (pinned or has windows).