### PR TITLE
Workaround for crashing when many tooltips are shown consecutively

### DIFF
--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -70,7 +70,7 @@ public class Dock.BaseItem : Gtk.Box {
 
     private int drag_offset_x = 0;
     private int drag_offset_y = 0;
-    private bool waiting_to_open_tooltip = false;
+    private uint open_tooltip_timeout_id = 0;
 
     protected BaseItem () {}
 
@@ -154,7 +154,10 @@ public class Dock.BaseItem : Gtk.Box {
             this.wait_and_show_tooltip (100);
         });
         motion_controller.leave.connect (() => {
-            this.waiting_to_open_tooltip = false;
+            if (open_tooltip_timeout_id > 0) {
+                GLib.Source.remove (open_tooltip_timeout_id);
+            }
+
             if (popover_tooltip.visible) popover_tooltip.popdown ();
         });
 
@@ -322,13 +325,11 @@ public class Dock.BaseItem : Gtk.Box {
             // Add timeout to avoid "Error 71 (Protocol error) dispatching to Wayland display".
             // This error is probably caused by a bug in GTK caused by the Nvidia driver at least up to v580.
             // Documented in issue #559 on the Github project.
-            waiting_to_open_tooltip = true;
-            GLib.Timeout.add (delay_ms, () => {
-                if (waiting_to_open_tooltip) {
-                    waiting_to_open_tooltip = false;
-                    if (!popover_menu.visible) {
-                        popover_tooltip.popup ();
-                    }
+
+            open_tooltip_timeout_id = GLib.Timeout.add (delay_ms, () => {
+                open_tooltip_timeout_id = 0;
+                if (!popover_menu.visible) {
+                    popover_tooltip.popup ();
                 }
 
                 return false;

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -151,14 +151,17 @@ public class Dock.BaseItem : Gtk.Box {
 
         var motion_controller = new Gtk.EventControllerMotion ();
         motion_controller.enter.connect (() => {
-            this.wait_and_show_tooltip (100);
+            wait_and_show_tooltip (100);
         });
         motion_controller.leave.connect (() => {
             if (open_tooltip_timeout_id > 0) {
                 GLib.Source.remove (open_tooltip_timeout_id);
+                open_tooltip_timeout_id = 0;
             }
 
-            if (popover_tooltip.visible) popover_tooltip.popdown ();
+            if (popover_tooltip.visible) {
+                popover_tooltip.popdown ();
+            }
         });
 
         add_controller (motion_controller);
@@ -324,15 +327,13 @@ public class Dock.BaseItem : Gtk.Box {
         if (!popover_menu.visible && tooltip_text != null) {
             // Add timeout to avoid "Error 71 (Protocol error) dispatching to Wayland display".
             // This error is probably caused by a bug in GTK caused by the Nvidia driver at least up to v580.
-            // Documented in issue #559 on the Github project.
+            // See https://github.com/elementary/dock/issues/559
 
-            open_tooltip_timeout_id = GLib.Timeout.add (delay_ms, () => {
+            open_tooltip_timeout_id = GLib.Timeout.add_once (delay_ms, () => {
                 open_tooltip_timeout_id = 0;
                 if (!popover_menu.visible) {
                     popover_tooltip.popup ();
                 }
-
-                return false;
             });
         }
     }


### PR DESCRIPTION
**Add delay of 100ms before showing dock tooltips:**
Fixes #559. After researching it, the culprit seems to be the Nvidia driver, which causes a problem with GTK.Popup, which is used as tooltips when hovering launchers in the doc since #441.

Adding a big enough delay before showing the tooltip seems to prevent the error (or at least making it very unlikely). I tried 1ms and it seemed to reduces the crashes quite a bit already, but I succeeded with 50ms by increasing the pointer speed, so I set it to 100ms.
This can also have a positive side effect: When rapidly hovering the launchers, every tooltip were briefly shown, but not long enough to be readable. So the delay makes it less distracting a restores the behaviour before #441.

~I only added the delay to the `Launcher` class, and not the parent `BaseItem`~. Feel free to rework the PR or close it to implement a cleaner fix. Maybe a proper fix should be added to GTK, but a simple workaround by adding a delay like here would not be acceptable I guess.