### PR TITLE
Make shell section into circle buttons

### DIFF
--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -76,17 +76,29 @@ public class Dock.Launcher : BaseItem {
 
         insert_action_group (App.ACTION_GROUP_PREFIX, app.app_action_group);
 
-        var shell_section = new Menu ();
-        shell_section.append (_("Keep in Dock"), ACTION_PREFIX + PINNED_ACTION);
+        var pinned_menuitem = new GLib.MenuItem (_("Keep in Dock"), ACTION_PREFIX + PINNED_ACTION);
+        pinned_menuitem.set_attribute_value ("verb-icon", "view-pin-symbolic");
+
+        var shell_menu = new Menu ();
+        shell_menu.append_item (pinned_menuitem);
 
         if (Environment.find_program_in_path ("io.elementary.appcenter") != null) {
-            shell_section.append (_("Uninstall"), App.ACTION_PREFIX + App.UNINSTALL_ACTION);
-            shell_section.append (_("View in AppCenter"), App.ACTION_PREFIX + App.VIEW_ACTION);
+            var uninstall_menuitem = new GLib.MenuItem (_("Uninstall"), App.ACTION_PREFIX + App.UNINSTALL_ACTION);
+            uninstall_menuitem.set_attribute_value ("verb-icon", "edit-delete-symbolic");
+
+            var view_info_menuitem = new GLib.MenuItem (_("View in AppCenter"), App.ACTION_PREFIX + App.VIEW_ACTION);
+            view_info_menuitem.set_attribute_value ("verb-icon", "dialog-information-symbolic");
+
+            shell_menu.append_item (uninstall_menuitem);
+            shell_menu.append_item (view_info_menuitem);
         }
+
+        var shell_section = new GLib.MenuItem.section (null, shell_menu);
+        shell_section.set_attribute_value ("display-hint", "circular-buttons");
 
         var menu = new Menu ();
         menu.append_section (null, app.app_action_menu);
-        menu.append_section (null, shell_section);
+        menu.append_item (shell_section);
 
         popover_menu = new Gtk.PopoverMenu.from_model (menu) {
             autohide = true,


### PR DESCRIPTION
Kind of Android style

<img width="343" height="246" alt="Screenshot from 2026-01-22 16 04 55" src="https://github.com/user-attachments/assets/179b7020-70f2-4b51-9fde-d4086cf7b6a0" />

- [ ] I think our menu button styles here aren't as good so I'd wanna wait until we land the new granite menu styles

<img width="276" height="244" alt="Screenshot from 2026-01-22 16 12 36" src="https://github.com/user-attachments/assets/31da7d9f-de81-4f08-ba51-061965aa38b3" />

- [ ] But granite is missing toggle styles https://github.com/elementary/granite/issues/941

- [ ] Semantically we should use `help-about` probably, but the star metaphor is kind of confusing in this context when pin is also right here I think