### PR TITLE
 Launcher: Use index for tooltip 

### DIFF
--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -98,7 +98,7 @@ public class Dock.Launcher : BaseItem {
         popover_menu.set_parent (this);
 
         update_tooltip ();
-        notify["current-pos"].connect (update_tooltip);
+        notify["index"].connect (update_tooltip);
         keybinding_settings.changed.connect (update_tooltip);
 
         image = new Gtk.Image ();
@@ -379,9 +379,8 @@ public class Dock.Launcher : BaseItem {
 
     private void update_tooltip () {
         string[] accels = {};
-        var index = (int) current_pos / ItemManager.get_launcher_size ();
         if (index < 9) {
-            accels = keybinding_settings.get_strv ("launch-dock-%i".printf (index + 1));
+            accels = keybinding_settings.get_strv ("launch-dock-%u".printf (index + 1));
         }
 
         tooltip_text = Granite.markup_accel_tooltip (

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -54,6 +54,17 @@ public class Dock.BaseItem : Gtk.Box {
 
     public State state { get; set; }
 
+    public uint index {
+        get {
+            var item_group = get_ancestor (typeof (ItemGroup)) as ItemGroup;
+            if (item_group == null) {
+                return Gtk.INVALID_LIST_POSITION;
+            }
+
+            return item_group.get_index_for_item (this);
+        }
+    }
+
     protected Gtk.Overlay overlay;
     protected Gtk.GestureClick gesture_click;
 
@@ -194,11 +205,6 @@ public class Dock.BaseItem : Gtk.Box {
         popover_tooltip.dispose ();
     }
 
-    public uint get_index () {
-        var item_group = get_ancestor (typeof (ItemGroup)) as ItemGroup;
-        return item_group?.get_index_for_item (this) ?? Gtk.INVALID_LIST_POSITION;
-    }
-
     public void set_revealed (bool revealed) {
         fade.skip ();
         reveal.skip ();
@@ -307,7 +313,7 @@ public class Dock.BaseItem : Gtk.Box {
      */
     public void calculate_dnd_move (BaseItem source, double x, double y) {
         var launcher_manager = ItemManager.get_default ();
-        launcher_manager.move_launcher_after (source, (int) get_index ());
+        launcher_manager.move_launcher_after (source, (int) index);
     }
 
     private bool on_drop (Value val) {

--- a/src/ItemGroup.vala
+++ b/src/ItemGroup.vala
@@ -74,6 +74,9 @@
         for (uint i = 0; i < current_children.get_n_items (); i++) {
             var item = (BaseItem) current_children.get_item (i);
             item.animate_move (get_launcher_size () * i);
+
+            /* Index might have changed so notify */
+            item.notify_property ("index");
         }
 
         relayout_queued = false;

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -173,8 +173,4 @@
         var app = (App) AppSystem.get_default ().apps.get_item (index - 1);
         app.launch (context);
     }
-
-    public static int get_launcher_size () {
-        return settings.get_int ("icon-size") + Launcher.PADDING * 2;
-    }
 }


### PR DESCRIPTION
Instead of manually calculating the index use the provided property of base item. Required some refactoring to make sure the index gets updated when it should. This will also make sure update_tooltip is called only once when reordering instead of on every frame like it's currently on main.