### PR TITLE
Change the way we deal with icon clipping

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -32,11 +32,6 @@ dock-window:not(.reduce-transparency) separator.vertical {
     border-right-color: alpha(@highlight_color, 0.15);
 }
 
-/* Keep enough room so that icons don't clip when bouncing */
-top-margin {
-    min-height: 64px;
-}
-
 bottom-margin {
     min-height: 9px;
 }

--- a/data/Application.css
+++ b/data/Application.css
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2023-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2023-2026 elementary, Inc. (https://elementary.io)
  */
 
 dock {
@@ -32,8 +32,9 @@ dock-window:not(.reduce-transparency) separator.vertical {
     border-right-color: alpha(@highlight_color, 0.15);
 }
 
-dock-window {
-    margin-top: 64px; /* Keep enough room so that icons don't clip when bouncing */
+/* Keep enough room so that icons don't clip when bouncing */
+top-margin {
+    min-height: 64px;
 }
 
 bottom-margin {

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2022-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2022-2026 elementary, Inc. (https://elementary.io)
  */
 
 public class Dock.Launcher : BaseItem {

--- a/src/AppSystem/Launcher.vala
+++ b/src/AppSystem/Launcher.vala
@@ -146,7 +146,7 @@ public class Dock.Launcher : BaseItem {
             valign = END
         };
 
-        insert_child_after (running_revealer, bin);
+        actionable_box.insert_child_after (running_revealer, bin);
 
         // We have to destroy the progressbar when it is not needed otherwise it will
         // cause continuous layouting of the surface see https://github.com/elementary/dock/issues/279

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -65,6 +65,11 @@ public class Dock.BaseItem : Gtk.Box {
         }
     }
 
+    /**
+     * A box that handles dnd and some other stuff.
+     * It's needed because top margin messes with dnd offsets and gsk transform.
+     */
+    protected Gtk.Box actionable_box;
     protected Gtk.Overlay overlay;
     protected Gtk.GestureClick gesture_click;
 
@@ -94,9 +99,12 @@ public class Dock.BaseItem : Gtk.Box {
             child = overlay
         };
 
+        actionable_box = new Gtk.Box (VERTICAL, 0);
+        actionable_box.append (bin);
+        actionable_box.append (new BottomMargin ());
+
         append (new TopMargin ());
-        append (bin);
-        append (new BottomMargin ());
+        append (actionable_box);
 
         var tooltip_label = new Gtk.Label (null) {
             use_markup = true
@@ -138,7 +146,7 @@ public class Dock.BaseItem : Gtk.Box {
             Granite.TRANSITION_DURATION_OPEN,
             new Adw.CallbackAnimationTarget ((val) => {
                 bin.allocate (icon_size, icon_size, -1,
-                    new Gsk.Transform ().translate (Graphene.Point () { y = TopMargin.SIZE + (float) val }
+                    new Gsk.Transform ().translate (Graphene.Point () { y = (float) val }
                 ));
             })
         );
@@ -194,7 +202,7 @@ public class Dock.BaseItem : Gtk.Box {
         var drag_source = new Gtk.DragSource () {
             actions = MOVE
         };
-        add_controller (drag_source);
+        actionable_box.add_controller (drag_source);
         drag_source.prepare.connect (on_drag_prepare);
         drag_source.drag_begin.connect (on_drag_begin);
         drag_source.drag_cancel.connect (on_drag_cancel);

--- a/src/BaseItem.vala
+++ b/src/BaseItem.vala
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2025-2026 elementary, Inc. (https://elementary.io)
  */
 
 public class Dock.BaseItem : Gtk.Box {
@@ -94,6 +94,7 @@ public class Dock.BaseItem : Gtk.Box {
             child = overlay
         };
 
+        append (new TopMargin ());
         append (bin);
         append (new BottomMargin ());
 
@@ -137,7 +138,7 @@ public class Dock.BaseItem : Gtk.Box {
             Granite.TRANSITION_DURATION_OPEN,
             new Adw.CallbackAnimationTarget ((val) => {
                 bin.allocate (icon_size, icon_size, -1,
-                    new Gsk.Transform ().translate (Graphene.Point () { y = (float) val }
+                    new Gsk.Transform ().translate (Graphene.Point () { y = TopMargin.SIZE + (float) val }
                 ));
             })
         );

--- a/src/BottomMargin.vala
+++ b/src/BottomMargin.vala
@@ -1,9 +1,9 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2025-2026 elementary, Inc. (https://elementary.io)
  */
 
-public class BottomMargin : Gtk.Widget {
+public class Dock.BottomMargin : Gtk.Widget {
     private static GLib.List<unowned BottomMargin> instances = new GLib.List<unowned BottomMargin> ();
 
     class construct {

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2023-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2023-2026 elementary, Inc. (https://elementary.io)
  */
 
  public class Dock.ItemManager : Gtk.Box {
@@ -8,10 +8,9 @@
 
     public Launcher? added_launcher { get; set; default = null; }
 
-    private DynamicWorkspaceIcon dynamic_workspace_item;
-
 #if WORKSPACE_SWITCHER
     private Gtk.Separator separator;
+    private DynamicWorkspaceIcon dynamic_workspace_item;
 #endif
 
     static construct {
@@ -25,19 +24,23 @@
         var background_group = new ItemGroup (background_item.group_model, (obj) => (BackgroundItem) obj);
 
 #if WORKSPACE_SWITCHER
-        dynamic_workspace_item = new DynamicWorkspaceIcon ();
-
         separator = new Gtk.Separator (VERTICAL) {
             valign = START,
             margin_top = Launcher.PADDING,
         };
         settings.bind ("icon-size", separator, "height-request", GET);
+
+        var separator_box = new Gtk.Box (VERTICAL, 0);
+        separator_box.append (new TopMargin ());
+        separator_box.append (separator);
+
+        dynamic_workspace_item = new DynamicWorkspaceIcon ();
 #endif
 
         append (app_group);
         append (background_group);
 #if WORKSPACE_SWITCHER
-        append (separator);
+        append (separator_box);
         append (new ItemGroup (WorkspaceSystem.get_default ().workspaces, (obj) => new WorkspaceIconGroup ((Workspace) obj)));
         append (dynamic_workspace_item);
 #endif

--- a/src/ItemManager.vala
+++ b/src/ItemManager.vala
@@ -25,8 +25,7 @@
 
 #if WORKSPACE_SWITCHER
         separator = new Gtk.Separator (VERTICAL) {
-            valign = START,
-            margin_top = Launcher.PADDING,
+            margin_top = Launcher.PADDING
         };
         settings.bind ("icon-size", separator, "height-request", GET);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0
- * SPDX-FileCopyrightText: 2022-2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2022-2026 elementary, Inc. (https://elementary.io)
  */
 
 public class Dock.MainWindow : Gtk.ApplicationWindow {
@@ -13,9 +13,6 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
             vexpand = true;
         }
     }
-
-    // Matches top margin in Launcher.css
-    private const int TOP_MARGIN = 64;
 
     private Settings transparency_settings;
     private static Settings settings = new Settings ("io.elementary.dock");
@@ -38,6 +35,7 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
         titlebar = new Gtk.Label ("") { visible = false };
 
         var dock_box = new Gtk.Box (VERTICAL, 0);
+        dock_box.append (new TopMargin ());
         dock_box.append (new Container ());
         dock_box.append (new BottomMargin ());
 
@@ -115,7 +113,7 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
             // bouncing isn't added by default and instead counts to the frame
             var item_manager_width = item_manager.get_width ();
             var shadow_size = (surface.width - item_manager_width) / 2;
-            var top_margin = TOP_MARGIN + shadow_size - 1;
+            var top_margin = TopMargin.SIZE + shadow_size - 1;
             size.set_shadow_width (shadow_size, shadow_size, top_margin, shadow_size);
         });
 
@@ -124,7 +122,7 @@ public class Dock.MainWindow : Gtk.ApplicationWindow {
             // and it still gets window events
             var item_manager_width = item_manager.get_width ();
             var shadow_size = (width - item_manager_width) / 2;
-            var top_margin = TOP_MARGIN + shadow_size;
+            var top_margin = TopMargin.SIZE + shadow_size;
             surface.set_input_region (new Cairo.Region.rectangle ({
                 shadow_size,
                 top_margin,

--- a/src/TopMargin.vala
+++ b/src/TopMargin.vala
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0
+ * SPDX-FileCopyrightText: 2026 elementary, Inc. (https://elementary.io)
+ */
+
+public class Dock.TopMargin : Gtk.Widget {
+    public const int SIZE = 64;
+
+    construct {
+        height_request = SIZE;
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,6 +8,7 @@ sources = [
     'ItemManager.vala',
     'MainWindow.vala',
     'RenderNodeWalker.vala',
+    'TopMargin.vala',
     'AppSystem' / 'App.vala',
     'AppSystem' / 'AppSystem.vala',
     'AppSystem' / 'Launcher.vala',


### PR DESCRIPTION
Part of https://github.com/elementary/dock/pull/598

Instead of BaseItem being `item` + `bottom_margin` + `overflow = VISIBLE` to show the bounce animation on the top, make it `top_margin` + `item` + `bottom_margin`, which eliminates the need in setting overflow and fixes an issue that appeared in https://github.com/elementary/dock/pull/598