### PR TITLE
App: use correct GPU name

### DIFF
--- a/src/AppSystem/App.vala
+++ b/src/AppSystem/App.vala
@@ -90,7 +90,7 @@ public class Dock.App : Object {
             app_action_group.add_action (switcheroo_action);
 
             app_action_menu.append (
-                _("Open with %s Graphics").printf (switcheroo_control.get_gpu_name (!prefers_nondefault_gpu)),
+                _("Open with %s Graphics").printf (switcheroo_control.get_gpu_name (prefers_nondefault_gpu)),
                 ACTION_PREFIX + SWITCHEROO_ACTION
             );
         }
@@ -132,7 +132,7 @@ public class Dock.App : Object {
         });
     }
 
-    public void launch (AppLaunchContext context, string? action = null, bool? use_preferred_gpu = true) {
+    public void launch (AppLaunchContext context, string? action = null, bool use_preferred_gpu = true) {
         launched ();
 
         if (use_preferred_gpu) {


### PR DESCRIPTION
Fixes https://github.com/elementary/dock/issues/581

The `switcheroo_control.get_gpu_name (bool default_gpu)` method, as its signature indicates, takes whether to return default GPU name. In case where app prefers non-default gpu, we need to get default name, and vice versa. But this was inversed when the switcheroo was introduced in https://github.com/elementary/dock/pull/228