### PR TITLE
Fix WorkspaceIconGroup memory leak

### DIFF
--- a/src/BaseIconGroup.vala
+++ b/src/BaseIconGroup.vala
@@ -24,42 +24,54 @@ public abstract class Dock.BaseIconGroup : ContainerItem {
         child = flow_box;
     }
 
-    private Gtk.Widget create_flow_box_child (Object? item) {
-        var image = new Gtk.Image.from_gicon ((Icon) item);
-        bind_property ("icon-size", image, "pixel-size", SYNC_CREATE, (binding, from_value, ref to_value) => {
-            var icon_size = from_value.get_int ();
-            to_value.set_int (get_pixel_size (icon_size));
-            return true;
-        });
-        // We use margin instead of grid spacing because grid spacing in combination with
-        // min children per line causes the flow box to request the grid spacing as additional width
-        // even when there is only one child making it off center.
-        bind_property ("icon-size", image, "margin-start", SYNC_CREATE, icon_size_to_margin);
-        bind_property ("icon-size", image, "margin-top", SYNC_CREATE, icon_size_to_margin);
-        bind_property ("icon-size", image, "margin-end", SYNC_CREATE, icon_size_to_margin);
-        bind_property ("icon-size", image, "margin-bottom", SYNC_CREATE, icon_size_to_margin);
-
+    private static Gtk.Widget create_flow_box_child (Object item) {
         return new Gtk.FlowBoxChild () {
-            child = image,
+            child = new CustomImage ((Icon) item),
             can_focus = false,
             can_target = false
         };
     }
 
-    private static bool icon_size_to_margin (Binding binding, Value from_value, ref Value to_value) {
-        var icon_size = from_value.get_int ();
-        var pixel_size = get_pixel_size (icon_size);
-        var spacing = (int) Math.round ((icon_size - pixel_size * MAX_IN_ROW) / 6);
-        to_value.set_int (spacing);
-        return true;
-    }
+    private class CustomImage : Granite.Bin {
+        private const string ICON_SIZE = "icon-size";
+        private static Settings settings = new Settings ("io.elementary.dock");
 
-    private static int get_pixel_size (int for_icon_size) {
-        switch (for_icon_size) {
-            case 64: return 24;
-            case 48: return 16;
-            case 32: return 8;
-            default: return (int) Math.round (for_icon_size / 3);
+        public Gtk.Image image { private get; construct; }
+
+        public CustomImage (Icon icon) {
+            Object (image: new Gtk.Image.from_gicon (icon));
+        }
+
+        construct {
+            child = image;
+
+            settings.changed[ICON_SIZE].connect (on_icon_size_changed);
+            on_icon_size_changed ();
+        }
+
+        private void on_icon_size_changed () {
+            var new_icon_size = settings.get_int (ICON_SIZE);
+            var new_pixel_size = icon_size_to_pixel_size (new_icon_size);
+
+            image.pixel_size = new_pixel_size;
+
+            // We use margin instead of grid spacing because grid spacing in combination with
+            // min children per line causes the flow box to request the grid spacing as additional width
+            // even when there is only one child making it off center.
+            var margin = (new_icon_size - new_pixel_size * MAX_IN_ROW) / 6;
+            margin_start = margin;
+            margin_top = margin;
+            margin_end = margin;
+            margin_bottom = margin;
+        }
+
+        private static int icon_size_to_pixel_size (int icon_size) {
+            switch (icon_size) {
+                case 64: return 24;
+                case 48: return 16;
+                case 32: return 8;
+                default: return (int) Math.round (icon_size / 3);
+            }
         }
     }
 }

--- a/src/WorkspaceSystem/WorkspaceIconGroup.vala
+++ b/src/WorkspaceSystem/WorkspaceIconGroup.vala
@@ -32,11 +32,7 @@ public class Dock.WorkspaceIconGroup : BaseIconGroup, WorkspaceItem {
     }
 
     construct {
-        workspace.bind_property ("is-active-workspace", this, "state", SYNC_CREATE, (binding, from_value, ref to_value) => {
-            var new_val = from_value.get_boolean () ? State.ACTIVE : State.HIDDEN;
-            to_value.set_enum (new_val);
-            return true;
-        });
+        workspace.bind_property ("is-active-workspace", this, "state", SYNC_CREATE, is_active_workspace_to_state);
 
         gesture_click.button = Gdk.BUTTON_PRIMARY;
         gesture_click.released.connect (workspace.activate);
@@ -54,5 +50,11 @@ public class Dock.WorkspaceIconGroup : BaseIconGroup, WorkspaceItem {
     public void window_left () {
         additional_icons.remove_all ();
         unset_state_flags (DROP_ACTIVE);
+    }
+
+    private static bool is_active_workspace_to_state (Binding binding, Value from_value, ref Value to_value) {
+        var new_val = from_value.get_boolean () ? State.ACTIVE : State.HIDDEN;
+        to_value.set_enum (new_val);
+        return true;
     }
 }


### PR DESCRIPTION
Use static methods for `GLib.Object.bind_property ()` and `Gtk.FlowBox.bind_model ()`