### PR TITLE
Fix App memory leak

### DIFF
--- a/src/AppSystem/AppSystem.vala
+++ b/src/AppSystem/AppSystem.vala
@@ -111,9 +111,8 @@ public class Dock.AppSystem : Object, UnityClient {
         }
 
         foreach (var app in id_to_app.get_values ()) {
-            GLib.GenericArray<Window>? window_list = null;
-            app_window_list.steal_extended (app, null, out window_list);
-            app.update_windows (window_list);
+            app.update_windows (app_window_list[app]);
+            app_window_list.remove (app);
         }
     }
 


### PR DESCRIPTION
The issue was in `GLib.HashTable.steal_extended` use. The whole point of `steal*` methods is to transfer ownership of the objects without calling destroy functions. But since the second argument (stolen key) was null, the ownership was never transferred and destroy function (`unref` if this case) was never called, which lead to memory leak.

Instead of dealing with convoluted method, just use `@get` and `remove`.