### PR TITLE
Show windows that are on all workspaces on all workspaces

### DIFF
--- a/src/WindowSystem/Window.vala
+++ b/src/WindowSystem/Window.vala
@@ -11,6 +11,7 @@ public class Dock.Window : GLib.Object {
     public bool has_focus { get; private set; default = false; }
     public int workspace_index { get; private set; default = 0; }
     public int64 time_appeared_on_workspace { get; private set; default = 0; }
+    public bool on_all_workspaces { get; private set; default = false; }
 
     public GLib.Icon icon { get; private set; default = new GLib.ThemedIcon ("application-default-icon"); }
 
@@ -33,6 +34,10 @@ public class Dock.Window : GLib.Object {
 
         if ("time-appeared-on-workspace" in properties) {
             time_appeared_on_workspace = (int64) properties["time-appeared-on-workspace"];
+        }
+
+        if ("on-all-workspaces" in properties) {
+            on_all_workspaces = (bool) properties["on-all-workspaces"];
         }
 
         var app_info = new GLib.DesktopAppInfo (app_id);

--- a/src/WorkspaceSystem/WorkspaceSystem.vala
+++ b/src/WorkspaceSystem/WorkspaceSystem.vala
@@ -41,6 +41,14 @@ public class Dock.WorkspaceSystem : Object {
         }
 
         foreach (var window in WindowSystem.get_default ().windows) {
+            if (window.on_all_workspaces) {
+                foreach (var window_list in workspace_window_list) {
+                    window_list.add (window);
+                }
+
+                continue;
+            }
+
             var workspace_index = window.workspace_index;
 
             if (workspace_index < 0 || workspace_index >= n_workspaces) {


### PR DESCRIPTION
Follow up to elementary/gala#2904. As suggested there show windows that are on all workspaces on all workspaces except the dynamic last one.

Requires elementary/gala#2910